### PR TITLE
Fix: Letter Pullup preview text visibility in dark mode

### DIFF
--- a/registry/components/magicui/letter-pullup.tsx
+++ b/registry/components/magicui/letter-pullup.tsx
@@ -40,7 +40,7 @@ export default function LetterPullup({
           initial = "initial"
           animate = "animate"
           custom = { i }
-          className = { cn("text-center font-display text-4xl font-bold tracking-[-0.02em] drop-shadow-sm md:text-4xl md:leading-[5rem]", className) }
+          className = { cn("text-center font-display text-4xl font-bold tracking-[-0.02em] drop-shadow-sm md:text-4xl md:leading-[5rem] dark:text-white", className) }
         >
           {letter === " " ? <span>&nbsp;</span> : letter}
         </motion.h1>


### PR DESCRIPTION
Fix #51
Update className to ensure text color is white in dark mode

<img width="1106" alt="Screenshot 2024-05-24 at 8 55 20 PM" src="https://github.com/magicuidesign/magicui/assets/109858950/db511289-8954-435e-857e-c12a01400fc6">
