### PR TITLE
fix: dark mode github star button number & use cn in number ticker class

### DIFF
--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -55,11 +55,11 @@ export async function SiteHeader({ user }: SiteHeaderProps) {
             <span className="absolute right-0 -mt-12 h-32 w-8 translate-x-12 rotate-12 transform bg-white opacity-10 transition-all duration-1000 ease-out group-hover:-translate-x-40" />
             <Icons.gitHub className="h-4 w-4" />
             Star on GitHub
-            <div className="hidden items-center gap-1 text-sm text-gray-500 md:flex">
-              <StarIcon className="h-4 w-4 transition-all duration-300 group-hover:text-yellow-300" />
+            <div className="hidden items-center gap-1 text-sm md:flex">
+              <StarIcon className="h-4 w-4 text-gray-500 transition-all duration-300 group-hover:text-yellow-300" />
               <NumberTicker
                 value={stars}
-                className="font-display font-medium text-white"
+                className="font-display font-medium text-white dark:text-black"
               />
             </div>
           </Link>

--- a/registry/components/magicui/number-ticker.tsx
+++ b/registry/components/magicui/number-ticker.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import { useInView, useMotionValue, useSpring } from "framer-motion";
 import { useEffect, useRef } from "react";
 
@@ -43,7 +44,10 @@ export default function NumberTicker({
 
   return (
     <span
-      className={`inline-block tabular-nums text-black dark:text-white ${className}`}
+      className={cn(
+        "inline-block tabular-nums text-black dark:text-white",
+        className,
+      )}
       ref={ref}
     />
   );


### PR DESCRIPTION
- Fix: Dark mode github star button number
- Feat: Use cn in number ticker class

Before:
<img width="223" alt="image" src="https://github.com/magicuidesign/magicui/assets/61398114/208cad41-7db7-4555-a694-51d1bbf28320">

After:
<img width="224" alt="image" src="https://github.com/magicuidesign/magicui/assets/61398114/e54e58e4-0823-4352-9ca1-7c53e0215b7a">
