### PR TITLE
:bug: [FIX] - fixed the bug that prevented the chevron from being display

### DIFF
--- a/components/landing/hero-client.tsx
+++ b/components/landing/hero-client.tsx
@@ -133,7 +133,7 @@ export default function HeroClient({ post }: { post: Doc }) {
                         size: "lg",
                       }),
                       "gap-2 whitespace-pre md:flex",
-                      "group relative w-full gap-1 overflow-hidden rounded-full text-sm font-semibold tracking-tighter",
+                      "group relative w-full gap-1 rounded-full text-sm font-semibold tracking-tighter",
                     )}
                   >
                     Browse Components


### PR DESCRIPTION
Fix Chevron Display on Button

Issue:
The chevron was not appearing on the button "Browse components"

Solution:
I have fixed the issue by adjusting the tailwind classes on the button.

Details of Changes:

On "hero-client" component at line "136" i deleted the overflow-hidden

Screenshots:

<img width="1462" alt="Capture d’écran 2024-05-25 à 19 20 53" src="https://github.com/magicuidesign/magicui/assets/97442265/d70d50f3-82fa-4f27-8c8c-e96a0d49b93e">
