### PR TITLE
Implement Svelte documentation

### DIFF
--- a/components/code-block-wrapper.tsx
+++ b/components/code-block-wrapper.tsx
@@ -6,22 +6,25 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import * as React from "react";
 
 interface CodeBlockProps extends React.HTMLAttributes<HTMLDivElement> {
   expandButtonTitle?: string;
+  multi?: boolean;
 }
 
 export function CodeBlockWrapper({
   expandButtonTitle = "View Code",
   className,
   children,
+  multi,
   ...props
 }: CodeBlockProps) {
   const [isOpened, setIsOpened] = React.useState(false);
 
-  return (
+  const renderContent = (content: React.ReactNode) => (
     <Collapsible open={isOpened} onOpenChange={setIsOpened}>
       <div className={cn("relative overflow-hidden", className)} {...props}>
         <CollapsibleContent
@@ -34,7 +37,7 @@ export function CodeBlockWrapper({
               !isOpened ? "[&_pre]:overflow-hidden" : "[&_pre]:overflow-auto]",
             )}
           >
-            {children}
+            {content}
           </div>
         </CollapsibleContent>
         <div
@@ -52,4 +55,23 @@ export function CodeBlockWrapper({
       </div>
     </Collapsible>
   );
+
+  if (multi) {
+    const childrenArray = React.Children.toArray(children);
+    const reactCode = childrenArray[0];
+    const svelteCode = childrenArray[1];
+
+    return (
+      <Tabs defaultValue="react" className="w-[400px]">
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="react">React</TabsTrigger>
+          <TabsTrigger value="svelte">Svelte 5</TabsTrigger>
+        </TabsList>
+        <TabsContent value="react">{renderContent(reactCode)}</TabsContent>
+        <TabsContent value="svelte">{renderContent(svelteCode)}</TabsContent>
+      </Tabs>
+    );
+  }
+
+  return renderContent(children);
 }

--- a/components/component-source.tsx
+++ b/components/component-source.tsx
@@ -6,15 +6,18 @@ import * as React from "react";
 
 interface ComponentSourceProps extends React.HTMLAttributes<HTMLDivElement> {
   src: string;
+  multi?: boolean;
 }
 
 export function ComponentSource({
   children,
   className,
+  multi,
   ...props
 }: ComponentSourceProps) {
   return (
     <CodeBlockWrapper
+      multi={multi}
       expandButtonTitle="Expand"
       className={cn("my-6 overflow-hidden rounded-md", className)}
       {...props}

--- a/content/docs/components/border-beam.mdx
+++ b/content/docs/components/border-beam.mdx
@@ -39,7 +39,7 @@ module.exports = {
 components/magicui/border-beam.tsx
 ```
 
-<ComponentSource name="border-beam" />
+<ComponentSource name="border-beam" multi="true" />
 
 </Steps>
 

--- a/lib/rehype-component.ts
+++ b/lib/rehype-component.ts
@@ -12,128 +12,114 @@ export function rehypeComponent() {
       const { value: src } = getNodeAttributeByName(node, "src") || {};
 
       if (node.name === "ComponentSource") {
-        const name = getNodeAttributeByName(node, "name")?.value as string;
-
-        if (!name) {
-          return null;
-        }
-
-        try {
-          // for (const style of styles) {
-          const component = registry[name];
-          const src = component.files[0];
-
-          // Read the source file.
-          const filePath = path.join(process.cwd(), src);
-          let source = fs.readFileSync(filePath, "utf8");
-
-          // Replace imports.
-          // TODO: Use @swc/core and a visitor to replace this.
-          // For now a simple regex should do.
-          source = source.replaceAll(`@/registry/`, "@/");
-          // source = source.replaceAll("export default", "export");
-
-          // Add code as children so that rehype can take over at build time.
-          node.children?.push(
-            u("element", {
-              tagName: "pre",
-              properties: {
-                __src__: src,
-              },
-              // attributes: [
-              //   {
-              //     name: "styleName",
-              //     type: "mdxJsxAttribute",
-              //     value: style.name,
-              //   },
-              // ],
-              children: [
-                u("element", {
-                  tagName: "code",
-                  properties: {
-                    className: ["language-tsx"],
-                  },
-                  data: {
-                    meta: `event="copy_source_code"`,
-                  },
-                  children: [
-                    {
-                      type: "text",
-                      value: source,
-                    },
-                  ],
-                }),
-              ],
-            }),
-          );
-          // }
-        } catch (error) {
-          console.error(error);
-        }
+        handleComponentSource(node);
       }
 
       if (node.name === "ComponentPreview" || node.name === "BlockPreview") {
-        const name = getNodeAttributeByName(node, "name")?.value as string;
-
-        if (!name) {
-          return null;
-        }
-
-        try {
-          // for (const style of styles) {
-          const component = registry[name];
-          const src = component.files[0];
-
-          // Read the source file.
-          const filePath = path.join(process.cwd(), src);
-          let source = fs.readFileSync(filePath, "utf8");
-
-          // console.log("name ", name);
-          // console.log("source ", source);
-
-          // Replace imports.
-          // TODO: Use @swc/core and a visitor to replace this.
-          // For now a simple regex should do.
-          source = source.replaceAll(`@/registry/`, "@/");
-          source = source.replaceAll("export default", "export");
-
-          // Add code as children so that rehype can take over at build time.
-          node.children?.push(
-            u("element", {
-              tagName: "pre",
-              properties: {
-                __src__: src,
-              },
-              children: [
-                u("element", {
-                  tagName: "code",
-                  properties: {
-                    className: ["language-tsx"],
-                  },
-                  data: {
-                    meta: `event="copy_usage_code"`,
-                  },
-                  children: [
-                    {
-                      type: "text",
-                      value: source,
-                    },
-                  ],
-                }),
-              ],
-            }),
-          );
-          // }
-        } catch (error) {
-          console.error(error);
-        }
+        handleComponentPreview(node);
       }
     });
   };
 }
 
+function handleComponentSource(node: UnistNode) {
+  const name = getNodeAttributeByName(node, "name")?.value as string;
+  const multi = getNodeAttributeByName(node, "multi")?.value as string;
+
+  if (!name) {
+    return null;
+  }
+
+  try {
+    const component = registry[name];
+
+    if (multi) {
+      const tsxSrc = component.files[0];
+      const svelteSrc = component.files[1];
+      const tsxSource = readFileContent(tsxSrc);
+      const svelteSource = readFileContent(svelteSrc);
+
+      addCodeAsChildren(node, tsxSrc, tsxSource, "tsx");
+      addCodeAsChildren(node, svelteSrc, svelteSource, "svelte");
+    } else {
+      const src = component.files[0];
+      const source = readFileContent(src);
+      addCodeAsChildren(node, src, source, "tsx"); // Assuming tsx as default language
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+function handleComponentPreview(node: UnistNode) {
+  const name = getNodeAttributeByName(node, "name")?.value as string;
+
+  if (!name) {
+    return null;
+  }
+
+  try {
+    const component = registry[name];
+    const src = component.files[0];
+    const source = readFileContent(src);
+
+    addCodeAsChildren(node, src, source, "tsx");
+  } catch (error) {
+    console.error(error);
+  }
+}
+
 function getNodeAttributeByName(node: UnistNode, name: string) {
   return node.attributes?.find((attribute) => attribute.name === name);
+}
+
+function readFileContent(src: string): string {
+  const filePath = path.join(process.cwd(), src);
+  let source = fs.readFileSync(filePath, "utf8");
+  source = replaceImports(source);
+  return source;
+}
+
+function replaceImports(source: string): string {
+  // Replace imports.
+  // TODO: Use @swc/core and a visitor to replace this.
+  // For now a simple regex should do.
+  source = source.replaceAll(`@/registry/`, "@/");
+  // source = source.replaceAll("export default", "export");
+  return source;
+}
+
+function addCodeAsChildren(
+  node: UnistNode,
+  src: string,
+  source: string,
+  language: string,
+) {
+  node.children?.push(
+    u("element", {
+      tagName: "pre",
+      properties: {
+        __src__: src,
+      },
+      children: [
+        u("element", {
+          tagName: "code",
+          properties: {
+            className: [`language-${language}`],
+          },
+          data: {
+            meta: `event="copy_source_code"`,
+          },
+          children: [
+            {
+              type: "text",
+              value: source,
+            },
+          ],
+        }),
+      ],
+    }),
+  );
 }
 
 // function getComponentSourceFileContent(node: UnistNode) {

--- a/registry/components/magicui/BorderBeam.svelte
+++ b/registry/components/magicui/BorderBeam.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import { cn } from "$lib/utils";
+
+  interface Props {
+    class?: string;
+    size?: number;
+    duration?: number;
+    borderWidth?: number;
+    anchor?: number;
+    colorFrom?: string;
+    colorTo?: string;
+    delay?: number;
+  }
+
+  let {
+    class: className,
+    size = 200,
+    duration = 15,
+    anchor = 90,
+    borderWidth = 1.5,
+    colorFrom = "#ffaa40",
+    colorTo = "#9c40ff",
+    delay = 0,
+  }: Props = $props();
+
+  let styleVars = $derived.by(() => {
+    return `--size: ${size}; 
+            --duration: ${duration}; 
+            --anchor: ${anchor}; 
+            --border-width: ${borderWidth}; 
+            --color-from: ${colorFrom}; 
+            --color-to: ${colorTo}; 
+            --delay: -${delay}s;`;
+  });
+</script>
+
+<div
+  style={styleVars}
+  class={cn(
+    "absolute inset-[0] rounded-[inherit] [border:calc(var(--border-width)*1px)_solid_transparent]",
+
+    // mask styles
+    "![mask-clip:padding-box,border-box] ![mask-composite:intersect] [mask:linear-gradient(transparent,transparent),linear-gradient(white,white)]",
+
+    // pseudo styles
+    "after:absolute after:aspect-square after:w-[calc(var(--size)*1px)] after:animate-border-beam after:[animation-delay:var(--delay)] after:[background:linear-gradient(to_left,var(--color-from),var(--color-to),transparent)] after:[offset-anchor:calc(var(--anchor)*1%)_50%] after:[offset-path:rect(0_auto_auto_0_round_calc(var(--size)*1px))]",
+    className,
+  )}
+></div>

--- a/registry/index.tsx
+++ b/registry/index.tsx
@@ -110,7 +110,10 @@ const ui: Registry = {
   "border-beam": {
     name: "border-beam",
     type: "components:ui",
-    files: ["registry/components/magicui/border-beam.tsx"],
+    files: [
+      "registry/components/magicui/border-beam.tsx",
+      "registry/components/magicui/BorderBeam.svelte",
+    ],
   },
   "animated-beam": {
     name: "animated-beam",


### PR DESCRIPTION
This PR implements some basic Svelte documentation, left it pretty barebones so it can be styled to fit in with the docs more.

It works with the "multi" prop on the ComponentSource component, which adds the tabs to code blocks

Also needed some rewriting of the rehype processor

Theres an example implementation in '/docs/components/border-beam' 