### PR TITLE
fix: cx set as cy in dot-pattern component

### DIFF
--- a/registry/components/magicui/dot-pattern.tsx
+++ b/registry/components/magicui/dot-pattern.tsx
@@ -44,7 +44,7 @@ export function DotPattern({
           x={x}
           y={y}
         >
-          <circle id="pattern-circle" cx={cy} cy={cy} r={cr} />
+          <circle id="pattern-circle" cx={cx} cy={cy} r={cr} />
         </pattern>
       </defs>
       <rect width="100%" height="100%" strokeWidth={0} fill={`url(#${id})`} />


### PR DESCRIPTION
> https://magicui.design/docs/components/dot-pattern

`cx={cy}` to `cx={cx}`

error: 'cx' is assigned a value but never used

<img width="508" alt="Screenshot 2024-06-01 at 12 49 30 PM" src="https://github.com/magicuidesign/magicui/assets/59228569/d0eaf506-297d-4814-bb38-121f6db6cf2b">
