### PR TITLE
Replace <h1> with <span>.

### DIFF
--- a/registry/components/magicui/fade-text.tsx
+++ b/registry/components/magicui/fade-text.tsx
@@ -53,7 +53,7 @@ export function FadeText({
       viewport={{ once: true }}
       variants={FADE_ANIMATION_VARIANTS}
     >
-      <motion.h1 className={className}>{text}</motion.h1>
+      <motion.span className={className}>{text}</motion.span>
     </motion.div>
   );
 }


### PR DESCRIPTION
Replace the h1 by the span, to respect the semantic/seo and that the user can use the text anywhere.

You only have to wrap the component with the desired tag:

```tsx
      <h1>
        <FadeText
          className=“text-4xl font-bold text-black dark:text-white”
          direction=“right”
          framerProps={{
            show: { transition: { delay: 0.4 } },
          }}
          text=“Fade Right”
        />
      </h1>
```

Translated with DeepL.com (free version)