### PR TITLE
[BUG FIX] Wrong import being used in example

### DIFF
--- a/registry/components/example/animated-shiny-text-demo.tsx
+++ b/registry/components/example/animated-shiny-text-demo.tsx
@@ -1,8 +1,8 @@
 import { cn } from "@/lib/utils";
-import TextShimmer from "@/registry/components/magicui/animated-shiny-text";
+import AnimatedShinyText from "@/registry/components/magicui/animated-shiny-text";
 import { ArrowRightIcon } from "@radix-ui/react-icons";
 
-export default async function TextShimmerDemo() {
+export default async function AnimatedShinyTextDemo() {
   return (
     <div className="z-10 flex min-h-[16rem] items-center justify-center">
       <div
@@ -10,10 +10,10 @@ export default async function TextShimmerDemo() {
           "group rounded-full border border-black/5 bg-neutral-100 text-base text-white transition-all ease-in hover:cursor-pointer hover:bg-neutral-200 dark:border-white/5 dark:bg-neutral-900 dark:hover:bg-neutral-800",
         )}
       >
-        <TextShimmer className="inline-flex items-center justify-center px-4 py-1 transition ease-out hover:text-neutral-600 hover:duration-300 hover:dark:text-neutral-400">
+        <AnimatedShinyText className="inline-flex items-center justify-center px-4 py-1 transition ease-out hover:text-neutral-600 hover:duration-300 hover:dark:text-neutral-400">
           <span>✨ Introducing Magic UI</span>
           <ArrowRightIcon className="ml-1 size-3 transition-transform duration-300 ease-in-out group-hover:translate-x-0.5" />
-        </TextShimmer>
+        </AnimatedShinyText>
       </div>
     </div>
   );


### PR DESCRIPTION
The example demonstrates using a component called "TextShimmer," which is imported from "@/components/magicui/animated-shiny-text". However, the file animated-shiny-text does not contain a TextShimmer export; it only exports AnimatedShinyText.

This fix makes use of the correct import in the demo.


OLD:
![image](https://github.com/magicuidesign/magicui/assets/106103625/f42fef53-0cc9-489a-8445-80a7c69cc270)

NEW:
![image](https://github.com/magicuidesign/magicui/assets/106103625/066aa6f1-f613-4047-b7b1-157852954dc2)
