### PR TITLE
Feature: Add Engyne as /blog

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+
+import type { NextRequest } from "next/server";
+
+export const config = {
+  matcher: [
+    "/((?!_next|api|[\\w-]+\\.\\w+).*)",
+  ],
+};
+
+export default async function middleware(req: NextRequest) {
+  const engyneSubdomain = "magicui" // change this to your Engyne subdomain
+  const url = req.nextUrl.clone();
+
+  const { pathname } = req.nextUrl;
+
+  const hostname = req.headers.get("host");
+  if (!hostname)
+    return new Response(null, {
+      status: 400,
+      statusText: "No hostname found in request headers",
+    });
+
+  if (pathname === "/engyne-sitemap.xml") {
+    return NextResponse.rewrite(
+      new URL(pathname, `https://${engyneSubdomain}.engyne.page`)
+    );
+  }
+
+  if (pathname.startsWith("/blog") || pathname.startsWith("/tags")) {
+    return NextResponse.rewrite(
+      new URL(pathname, `https://${engyneSubdomain}.engyne.page`)
+    );
+  }
+  if (pathname.startsWith("/_engyne")) {
+    return NextResponse.rewrite(
+      new URL(pathname, `https://${engyneSubdomain}.engyne.page`)
+    );
+  }
+
+  return NextResponse.next();
+}


### PR DESCRIPTION
Adds the `middleware.ts` file to deploy `https://magicui.engyne.page/` as `/blog`

How to test:
- Install & Run the project
- Navigate to http://localhost:3000/blog, you should a list of blog posts
- Navigate to http://localhost:3000/blog/tailwind-font-size, you should see a blog post about Tailwind Font Size

Before deploy, make sure that all other routes are still reachable.

![image](https://github.com/magicuidesign/magicui/assets/6132555/a0b51d83-b05e-4521-a9de-bcf241fa143b)
