### PR TITLE
fix: animate-subscribe-button-color

### DIFF
--- a/content/docs/components/animated-subscribe-button.mdx
+++ b/content/docs/components/animated-subscribe-button.mdx
@@ -26,9 +26,9 @@ components/magicui/animated-subscribe-button.tsx
 
 | Prop                | Type    | Description                                                                                                                                                   |
 | ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **brand**           | string  | The accent color for the button. This allows you to set a custom color that matches your brand's theme.                                                       |
-| **subscribeStatus** | boolean | A boolean flag to check the condition for the button. This property can be used to toggle the button's state, such as subscribed or unsubscribed.             |
+| **buttonColor**     | string  | The accent color for the button. This allows you to set a custom color that matches your brand's theme.                                                       |
 | **buttonTextColor** | string  | The color of the button text. This allows you to ensure the text is visible and matches your desired color scheme.                                            |
+| **subscribeStatus** | boolean | A boolean flag to check the condition for the button. This property can be used to toggle the button's state, such as subscribed or unsubscribed.             |
 | **initialText**     | string  | The initial text displayed on the button. This is useful for setting a default label when the button first appears.                                           |
 | **changeText**      | string  | The final text displayed on the button after an action has been taken. This can be used to indicate a state change, such as from "Subscribe" to "Subscribed". |
 

--- a/registry/components/example/animated-subscribe-button-demo.tsx
+++ b/registry/components/example/animated-subscribe-button-demo.tsx
@@ -1,24 +1,24 @@
-import { AnimatedSubscribeButton } from "@/registry/components/magicui/animated-subscribe-button"
-import { CheckIcon, ChevronRightIcon } from "lucide-react"
+import { AnimatedSubscribeButton } from "@/registry/components/magicui/animated-subscribe-button";
+import { CheckIcon, ChevronRightIcon } from "lucide-react";
 
 export default function AnimatedSubscribeButtonDemo() {
   return (
     <AnimatedSubscribeButton
-      buttonColor = "#000000"
-      buttonTextColor = "#ffffff"
-      subscribeStatus = { false }
-      initialText = {
-        <span className = "group inline-flex items-center">
+      buttonColor="#000000"
+      buttonTextColor="#ffffff"
+      subscribeStatus={false}
+      initialText={
+        <span className="group inline-flex items-center">
           Subscribe{" "}
-          <ChevronRightIcon className = "ml-1 h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
+          <ChevronRightIcon className="ml-1 h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
         </span>
       }
-      changeText = {
-        <span className = "group inline-flex items-center">
-          <CheckIcon className = "mr-2 h-4 w-4" />
+      changeText={
+        <span className="group inline-flex items-center">
+          <CheckIcon className="mr-2 h-4 w-4" />
           Subscribed{" "}
         </span>
       }
     />
-  )
+  );
 }

--- a/registry/components/example/animated-subscribe-button-demo.tsx
+++ b/registry/components/example/animated-subscribe-button-demo.tsx
@@ -1,24 +1,24 @@
-import { AnimatedSubscribeButton } from "@/registry/components/magicui/animated-subscribe-button";
-import { CheckIcon, ChevronRightIcon } from "lucide-react";
+import { AnimatedSubscribeButton } from "@/registry/components/magicui/animated-subscribe-button"
+import { CheckIcon, ChevronRightIcon } from "lucide-react"
 
 export default function AnimatedSubscribeButtonDemo() {
   return (
     <AnimatedSubscribeButton
-      brand="#ffbd7a"
-      subscribeStatus={false}
-      buttonTextColor="#000009"
-      initialText={
-        <span className="group inline-flex items-center">
+      buttonColor = "#000000"
+      buttonTextColor = "#ffffff"
+      subscribeStatus = { false }
+      initialText = {
+        <span className = "group inline-flex items-center">
           Subscribe{" "}
-          <ChevronRightIcon className="ml-1 h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
+          <ChevronRightIcon className = "ml-1 h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
         </span>
       }
-      changeText={
-        <span className="group inline-flex items-center">
-          <CheckIcon className="mr-2 h-4 w-4" />
+      changeText = {
+        <span className = "group inline-flex items-center">
+          <CheckIcon className = "mr-2 h-4 w-4" />
           Subscribed{" "}
         </span>
       }
     />
-  );
+  )
 }

--- a/registry/components/magicui/animated-subscribe-button.tsx
+++ b/registry/components/magicui/animated-subscribe-button.tsx
@@ -4,16 +4,16 @@ import { AnimatePresence, motion } from "framer-motion";
 import React, { useState } from "react";
 
 interface AnimatedSubscribeButtonProps {
-  brand: string;
-  subscribeStatus: boolean;
+  buttonColor: string;
   buttonTextColor?: string;
+  subscribeStatus: boolean;
   initialText: React.ReactElement | string;
   changeText: React.ReactElement | string;
 }
 
 export const AnimatedSubscribeButton: React.FC<
   AnimatedSubscribeButtonProps
-> = ({ brand, subscribeStatus, buttonTextColor, changeText, initialText }) => {
+> = ({ buttonColor, subscribeStatus, buttonTextColor, changeText, initialText }) => {
   const [isSubscribed, setIsSubscribed] = useState<boolean>(subscribeStatus);
 
   return (
@@ -31,7 +31,7 @@ export const AnimatedSubscribeButton: React.FC<
             className="relative block h-full w-full font-semibold"
             initial={{ y: -50 }}
             animate={{ y: 0 }}
-            style={{ color: brand }}
+            style={{ color: buttonColor }}
           >
             {changeText}
           </motion.span>
@@ -39,7 +39,7 @@ export const AnimatedSubscribeButton: React.FC<
       ) : (
         <motion.button
           className="relative flex w-[200px] cursor-pointer items-center justify-center rounded-md border-none p-[10px]"
-          style={{ backgroundColor: brand, color: buttonTextColor }}
+          style={{ backgroundColor: buttonColor, color: buttonTextColor }}
           onClick={() => setIsSubscribed(true)}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}

--- a/registry/components/magicui/animated-subscribe-button.tsx
+++ b/registry/components/magicui/animated-subscribe-button.tsx
@@ -13,14 +13,20 @@ interface AnimatedSubscribeButtonProps {
 
 export const AnimatedSubscribeButton: React.FC<
   AnimatedSubscribeButtonProps
-> = ({ buttonColor, subscribeStatus, buttonTextColor, changeText, initialText }) => {
+> = ({
+  buttonColor,
+  subscribeStatus,
+  buttonTextColor,
+  changeText,
+  initialText,
+}) => {
   const [isSubscribed, setIsSubscribed] = useState<boolean>(subscribeStatus);
 
   return (
     <AnimatePresence mode="wait">
       {isSubscribed ? (
         <motion.button
-          className="relative flex w-[200px] items-center justify-center bg-white p-[10px]"
+          className="relative flex w-[200px] items-center justify-center overflow-hidden rounded-md bg-white p-[10px] outline outline-1 outline-black"
           onClick={() => setIsSubscribed(false)}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}


### PR DESCRIPTION
Addresses issue: https://github.com/magicuidesign/magicui/issues/135

Changes Made:
- Updated **AnimatedSubscribeButton** color to black/white
- Renamed prop **brand** to **buttonColor** for clarity and replaced references.
- Updated docs.

<img width="506" alt="Screenshot 2024-06-06 at 8 46 59 PM" src="https://github.com/magicuidesign/magicui/assets/20110627/5903c89b-1943-43cd-9f20-fa19947cfc68">

<img width="650" alt="Screenshot 2024-06-06 at 10 48 32 PM" src="https://github.com/magicuidesign/magicui/assets/20110627/61066935-42ff-4837-8ef8-011dc4966cda">

