### PR TITLE
fix: gauge-circle-docs

### DIFF
--- a/content/docs/components/gauge-circle.mdx
+++ b/content/docs/components/gauge-circle.mdx
@@ -14,6 +14,10 @@ published: true
 
 Copy and paste the following code into your project.
 
+```text
+components/magicui/guage-circle.tsx
+```
+
 <ComponentSource name="gauge-circle" />
 
 </Steps>

--- a/content/docs/components/gauge-circle.mdx
+++ b/content/docs/components/gauge-circle.mdx
@@ -15,7 +15,7 @@ published: true
 Copy and paste the following code into your project.
 
 ```text
-components/magicui/guage-circle.tsx
+components/magicui/gauge-circle.tsx
 ```
 
 <ComponentSource name="gauge-circle" />


### PR DESCRIPTION
Addresses: https://github.com/magicuidesign/magicui/issues/133

Changes Made:
- Added guage-circle.tsx file path to docs.

<img width="477" alt="Screenshot 2024-06-06 at 8 57 37 PM" src="https://github.com/magicuidesign/magicui/assets/20110627/669a1245-a40d-4fd1-a94e-67a8fa0314fa">
