### PR TITLE
fix: prevent duplicated characters in typing animation.

### DIFF
--- a/registry/components/magicui/typing-animation.tsx
+++ b/registry/components/magicui/typing-animation.tsx
@@ -20,7 +20,7 @@ export default function TypingAnimation({
   useEffect(() => {
     const typingEffect = setInterval(() => {
       if (i < text.length) {
-        setDisplayedText((prevState) => prevState + text.charAt(i));
+        setDisplayedText(text.substring(0, i + 1));
         setI(i + 1);
       } else {
         clearInterval(typingEffect);


### PR DESCRIPTION
Changed the `<TypingAnimation />` component logic to avoid duplicated characters by updating it to use `text.substring(..)` instead of concatenating with `prevState + text.charAt(i)`.

### Context
Using small durations, e.g., `<TypingAnimation duration={5} />`, can duplicate characters. This does not always happen, but when switching tabs or when the application is in the background, it is more prone to happen.

