### PR TITLE
refactor: create independent types definitions for the component's props

### DIFF
--- a/registry/components/magicui/animated-list.tsx
+++ b/registry/components/magicui/animated-list.tsx
@@ -3,16 +3,14 @@
 import { AnimatePresence, motion } from "framer-motion";
 import React, { ReactElement, useEffect, useMemo, useState } from "react";
 
+type AnimatedListProps = {
+  className?: string;
+  children: React.ReactNode;
+  delay?: number;
+};
+
 export const AnimatedList = React.memo(
-  ({
-    className,
-    children,
-    delay = 1000,
-  }: {
-    className?: string;
-    children: React.ReactNode;
-    delay?: number;
-  }) => {
+  ({ className, children, delay = 1000 }: AnimatedListProps) => {
     const [index, setIndex] = useState(0);
     const childrenArray = React.Children.toArray(children);
 

--- a/registry/components/magicui/animated-list.tsx
+++ b/registry/components/magicui/animated-list.tsx
@@ -3,11 +3,11 @@
 import { AnimatePresence, motion } from "framer-motion";
 import React, { ReactElement, useEffect, useMemo, useState } from "react";
 
-type AnimatedListProps = {
+export interface AnimatedListProps {
   className?: string;
   children: React.ReactNode;
   delay?: number;
-};
+}
 
 export const AnimatedList = React.memo(
   ({ className, children, delay = 1000 }: AnimatedListProps) => {


### PR DESCRIPTION
## Description

This pull request aims to enhance code maintainability and readability, by **extracting the types for component props** into separate type definitions. 

This refactor ensures a cleaner separation of concerns, making it easier to manage and update prop types across the codebase.

## Changes Made

- [x] Extracted the types of props in independent definitions.