### PR TITLE
Fix Number Ticker Component Spacing Issue (#160)

### DIFF
--- a/registry/components/magicui/number-ticker.tsx
+++ b/registry/components/magicui/number-ticker.tsx
@@ -45,7 +45,7 @@ export default function NumberTicker({
   return (
     <span
       className={cn(
-        "inline-block tabular-nums text-black dark:text-white",
+        "inline-block tabular-nums text-black dark:text-white tracking-wider",
         className,
       )}
       ref={ref}


### PR DESCRIPTION
### Description:

Hi @dillionverma,

While reviewing Issue #160 reported by @alamenai, I noticed that the last two digits in the Number Ticker component were attached together, and there was no space between them.

#### Issue Screenshot:
![image](https://github.com/magicuidesign/magicui/assets/98586665/4b46af63-76ba-41e0-93c6-ed1f9f771077)

@itsarghyadas commented a few days ago suspecting that the issue might be caused by the `tabular-nums` className. To address this, I have applied the `tracking-wider` class from Tailwind CSS to the component, which resolved the spacing issue.

### Solution:

Here is the updated code snippet with the `tracking-wider` class added:

```typescript
return (
   <span
      className={cn(
         'inline-block tabular-nums text-black dark:text-white tracking-wider',
         className,
      )}
      ref={ref}
   />
)
```

### Updated Component Screenshot:
![image](https://github.com/magicuidesign/magicui/assets/98586665/43b645ed-ba86-4785-a479-b995ab30e893)

### Reviewers:
- @dillionverma
- @itsarghyadas

### Testing:

- Confirm that the number ticker now displays digits with appropriate spacing.
- Verify that the addition of `tracking-wider` does not introduce any new layout issues.

Thanks,
Nyxb