### PR TITLE
fix: ripple component display name

### DIFF
--- a/registry/components/magicui/ripple.tsx
+++ b/registry/components/magicui/ripple.tsx
@@ -26,4 +26,6 @@ const Ripple = React.memo(() => {
   );
 });
 
+Ripple.displayName = "Ripple";
+
 export default Ripple;


### PR DESCRIPTION
Fixed an issue with Vercel deployments and TS warnings in Ripple component as per this issue: https://github.com/magicuidesign/magicui/issues/168

