### PR TITLE
fix: improve accessibility of border beam component

### DIFF
--- a/registry/components/magicui/border-beam.tsx
+++ b/registry/components/magicui/border-beam.tsx
@@ -35,7 +35,7 @@ export const BorderBeam = ({
         } as React.CSSProperties
       }
       className={cn(
-        "absolute inset-[0] rounded-[inherit] [border:calc(var(--border-width)*1px)_solid_transparent]",
+        "pointer-events-none absolute inset-[0] rounded-[inherit] [border:calc(var(--border-width)*1px)_solid_transparent]",
 
         // mask styles
         "![mask-clip:padding-box,border-box] ![mask-composite:intersect] [mask:linear-gradient(transparent,transparent),linear-gradient(white,white)]",


### PR DESCRIPTION
Issue:
When placing the border beam component around a card, the contents inside it become unclickable. I encountered this issue recently when trying to use the component along with a pricing component. For images, this is not a big deal, but for any buttons/links/texts this should be fixed.

My suggestion is adding the `pointer-events-none` tailwind class, which resolves the issue.

Changes made:
- Updated `registry/components/magicui/border-beam.tsx` component by adding the tailwind class to the div