### PR TITLE
fix: height change after button click

### DIFF
--- a/registry/components/magicui/animated-subscribe-button.tsx
+++ b/registry/components/magicui/animated-subscribe-button.tsx
@@ -26,7 +26,7 @@ export const AnimatedSubscribeButton: React.FC<
     <AnimatePresence mode="wait">
       {isSubscribed ? (
         <motion.button
-          className="relative flex w-[200px] items-center justify-center overflow-hidden rounded-md bg-white p-[10px] outline outline-1 outline-black"
+          className="relative flex w-[200px] items-center justify-center overflow-hidden rounded-md bg-white p-[10px] outline outline-1 outline-black h-[46px]"
           onClick={() => setIsSubscribed(false)}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -44,7 +44,7 @@ export const AnimatedSubscribeButton: React.FC<
         </motion.button>
       ) : (
         <motion.button
-          className="relative flex w-[200px] cursor-pointer items-center justify-center rounded-md border-none p-[10px]"
+          className="relative flex w-[200px] cursor-pointer items-center justify-center rounded-md border-none p-[10px] h-[46px]"
           style={{ backgroundColor: buttonColor, color: buttonTextColor }}
           onClick={() => setIsSubscribed(true)}
           initial={{ opacity: 0 }}


### PR DESCRIPTION
fixes: #197
Quite possibly framer-motion is adding up some more height to the button.
Simply adding a fixed height to the button does the job.