### PR TITLE
feat: don't show last circle in case numPeople is null or under 0

### DIFF
--- a/registry/default/magicui/avatar-circles.tsx
+++ b/registry/default/magicui/avatar-circles.tsx
@@ -39,10 +39,10 @@ const AvatarCircles = ({
           />
         </a>
       ))}
-      {numPeople && (
+      {(numPeople ?? 0) > 0 && (
         <a
           className="flex h-10 w-10 items-center justify-center rounded-full border-2 border-white bg-black text-center text-xs font-medium text-white hover:bg-gray-600 dark:border-gray-800 dark:bg-white dark:text-black"
-          href="#"
+          href=""
         >
           +{numPeople}
         </a>


### PR DESCRIPTION
![Screenshot from 2024-07-27 21-16-23](https://github.com/user-attachments/assets/fdf01aa2-fa11-4292-8a3f-8c93cc495815)

This commit removes the +0 or null

![Screenshot from 2024-07-27 21-18-53](https://github.com/user-attachments/assets/70efa9dd-1e98-4327-a980-5c9d1cd6a8e8)
![Screenshot from 2024-07-27 21-21-07](https://github.com/user-attachments/assets/a928357a-e0c5-4add-b3f5-434e430b9c09)
