### PR TITLE
fix(command): adjust class to new cmdk version

### DIFF
--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -117,7 +117,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground aria-disabled:pointer-events-none aria-disabled:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-selected:bg-accent aria-selected:text-accent-foreground",
       className,
     )}
     {...props}

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -117,7 +117,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground aria-disabled:pointer-events-none aria-disabled:opacity-50",
       className,
     )}
     {...props}


### PR DESCRIPTION
The Command component was not using the correct selector for disabled items. This is due to the new version (1.0) of the cmdk, which uses aria-disabled and data-disabled as booleans instead of undefined.

All items inside command-menu are disabled now. You can check here:
![Currently with all items disabled](https://github.com/user-attachments/assets/f2f63a1c-1d79-4e2a-9896-87297194a861)

You can check the `cmdk` CHANGELOG [here](https://github.com/pacocoursey/cmdk/releases/tag/v1.0.0)
![cmdk CHANGELOG](https://github.com/user-attachments/assets/00a39000-f7c5-499a-8d72-b6cb06fbbdfa)