### PR TITLE
fix: `husky install` command is deprecated in husky@v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:fix": "next lint --fix",
     "format:write": "prettier --write \"**/*.{ts,tsx,mdx}\" --cache",
     "format:check": "prettier --check \"**/*.{ts,tsx,mdx}\" --cache",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "dependencies": {
     "@heroicons/react": "^2.1.3",


### PR DESCRIPTION
`husky install` is deprecated in husky@v9.
[https://github.com/typicode/husky/releases/tag/v9.0.1](https://github.com/typicode/husky/releases/tag/v9.0.1)

fix:
<img width="238" alt="image" src="https://github.com/user-attachments/assets/486b506b-3988-4e08-9e0e-511671c8ea26">
