### PR TITLE
docs(text-reveal): remote prop `children`

### DIFF
--- a/content/docs/components/text-reveal.mdx
+++ b/content/docs/components/text-reveal.mdx
@@ -45,7 +45,6 @@ npx magicui-cli add text-reveal
 
 | Prop      | Type   | Description                                  | Default |
 | --------- | ------ | -------------------------------------------- | ------- |
-| children  |        | The text to be shimmered.                    |         |
 | className | string | The class name to be applied to the shimmer. |         |
 | text      | string | The text to do the animation for             | ""      |
 


### PR DESCRIPTION
`text-reveal` component doesn't have children
<img width="504" alt="image" src="https://github.com/user-attachments/assets/96ac74d3-1519-4443-b07b-7073db705d18">
