### PR TITLE
fix: command menu overflow display

### DIFF
--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -15,7 +15,7 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      "flex size-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      "flex size-full flex-col rounded-md bg-popover text-popover-foreground",
       className,
     )}
     {...props}


### PR DESCRIPTION
**The command menu items on the home page have the contents blurred.**
This happens all the time if the menu height exceeds the items' height. This is a fix for that

this

![Screenshot 2024-08-14 at 3 59 39 PM](https://github.com/user-attachments/assets/05a0d9bc-03bd-4141-8bad-e7b2efacf03b)

changes to

![Screenshot 2024-08-14 at 3 58 01 PM](https://github.com/user-attachments/assets/1f4c24d1-e30c-4c2f-8e21-40b4ea6507e8)


