### PR TITLE
feat: add number-ticker to accept decimal places

### DIFF
--- a/content/docs/components/number-ticker.mdx
+++ b/content/docs/components/number-ticker.mdx
@@ -41,9 +41,17 @@ npx magicui-cli add number-ticker
 
 </Tabs>
 
+## Example
+
+### Decimal
+
+<ComponentPreview name="number-ticker-decimal-demo" />
+
 ## Props
 
-| Prop      | Type       | Description               | Default |
-| --------- | ---------- | ------------------------- | ------- |
-| value     | int        | The value to count to     | 0       |
-| direction | up \| down | The direction to count in | up      |
+| Prop          | Type       | Description                          | Default |
+| ------------- | ---------- | ------------------------------------ | ------- |
+| value         | int        | The value to count to                | 0       |
+| direction     | up \| down | The direction to count in            | up      |
+| delay         | number     | The delay before counting            | 0       |
+| decimalPlaces | number     | The number of decimal places to show | 0       |

--- a/registry/components/example/number-ticker-decimal-demo.tsx
+++ b/registry/components/example/number-ticker-decimal-demo.tsx
@@ -1,0 +1,11 @@
+import NumberTicker from "@/components/magicui/number-ticker";
+
+const NumberTickerDemo = () => {
+  return (
+    <p className="whitespace-pre-wrap text-8xl font-medium tracking-tighter text-black dark:text-white">
+      <NumberTicker value={5.67} decimalPlaces={2} />
+    </p>
+  );
+};
+
+export default NumberTickerDemo;

--- a/registry/components/magicui/number-ticker.tsx
+++ b/registry/components/magicui/number-ticker.tsx
@@ -10,11 +10,13 @@ export default function NumberTicker({
   direction = "up",
   delay = 0,
   className,
+  decimalPlaces = 0,
 }: {
   value: number;
   direction?: "up" | "down";
   className?: string;
   delay?: number; // delay in s
+  decimalPlaces?: number;
 }) {
   const ref = useRef<HTMLSpanElement>(null);
   const motionValue = useMotionValue(direction === "down" ? value : 0);
@@ -35,12 +37,13 @@ export default function NumberTicker({
     () =>
       springValue.on("change", (latest) => {
         if (ref.current) {
-          ref.current.textContent = Intl.NumberFormat("en-US").format(
-            Number(latest.toFixed(0)),
-          );
+          ref.current.textContent = Intl.NumberFormat("en-US", {
+            minimumFractionDigits: decimalPlaces,
+            maximumFractionDigits: decimalPlaces,
+          }).format(Number(latest.toFixed(decimalPlaces)));
         }
       }),
-    [springValue],
+    [springValue, decimalPlaces],
   );
 
   return (

--- a/registry/index.tsx
+++ b/registry/index.tsx
@@ -499,6 +499,15 @@ const example: Registry = {
       () => import("@/registry/components/example/number-ticker-demo"),
     ),
   },
+  "number-ticker-decimal-demo": {
+    name: "number-ticker-decimal-demo",
+    type: "components:example",
+    registryDependencies: ["number-ticker"],
+    files: ["registry/components/example/number-ticker-decimal-demo.tsx"],
+    component: React.lazy(
+      () => import("@/registry/components/example/number-ticker-decimal-demo"),
+    ),
+  },
   "ripple-demo": {
     name: "ripple-demo",
     type: "components:example",


### PR DESCRIPTION
Update number-ticker component by allowing it to accept and display decimal places. This feature will provide more flexibility in presenting non-integer numbers within the ticker component.

### Changes:

- Updated the number-ticker to handle decimal places input by adding `decimalPlaces` props.
- Added `number-ticker-decimal-demo` basic showcase.
- Update `number-ticker.mdx` docs.

[magicui-number-ticker-decimal.webm](https://github.com/user-attachments/assets/260d50f1-d2d4-4757-8808-000c091892c0)
