### PR TITLE
feat: adding following active animaton on the sidebar nav menu items

### DIFF
--- a/components/sidebar-nav.tsx
+++ b/components/sidebar-nav.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { SidebarNavItem } from "@/types";
 import { ExternalLinkIcon } from "@radix-ui/react-icons";
+import { motion } from "framer-motion";
 import posthog from "posthog-js";
 
 import { cn } from "@/lib/utils";
@@ -23,7 +24,11 @@ export function DocsSidebarNav({ items }: DocsSidebarNavProps) {
             {item.title}
           </h4>
           {item?.items && (
-            <DocsSidebarNavItems items={item.items} pathname={pathname} />
+            <DocsSidebarNavItems
+              items={item.items}
+              pathname={pathname}
+              groupId={`group-${index}`}
+            />
           )}
         </div>
       ))}
@@ -34,14 +39,16 @@ export function DocsSidebarNav({ items }: DocsSidebarNavProps) {
 interface DocsSidebarNavItemsProps {
   items: SidebarNavItem[];
   pathname: string | null;
+  groupId: string;
 }
 
 export function DocsSidebarNavItems({
   items,
   pathname,
+  groupId,
 }: DocsSidebarNavItemsProps) {
   return items?.length ? (
-    <div className="grid grid-flow-row auto-rows-max text-sm">
+    <div className="grid grid-flow-row auto-rows-max text-sm gap-0.5 relative">
       {items.map((item, index) =>
         item.href && !item.disabled ? (
           <Link
@@ -49,7 +56,7 @@ export function DocsSidebarNavItems({
             href={item.href}
             onClick={() => item.event && posthog.capture(item.event)}
             className={cn(
-              "group flex w-full items-center rounded-md border border-transparent px-2 py-1 hover:underline",
+              "group flex w-full items-center rounded-md border border-transparent px-2 py-1 relative",
               item.disabled && "cursor-not-allowed opacity-60",
               pathname === item.href
                 ? "font-medium text-foreground"
@@ -58,24 +65,40 @@ export function DocsSidebarNavItems({
             target={item.external ? "_blank" : ""}
             rel={item.external ? "noreferrer" : ""}
           >
-            <span className="shrink-0">{item.title}</span>
+            {pathname === item.href && (
+              <motion.div
+                layoutId={groupId}
+                className="absolute border-l-2 border-neutral-300 dark:border-neutral-600 inset-0 rounded-r-md bg-neutral-100 dark:bg-neutral-800"
+                initial={false}
+                transition={{
+                  type: "spring",
+                  stiffness: 350,
+                  damping: 30,
+                  mass: 1,
+                  velocity: 200,
+                }}
+              />
+            )}
+            <span className="relative z-10 shrink-0">{item.title}</span>
             {item.label && (
-              <span className="ml-2 rounded-md bg-[#FFBD7A] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
+              <span className="relative z-10 ml-2 rounded-md bg-[#FFBD7A] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
                 {item.label}
               </span>
             )}
             {item.paid && (
-              <span className="ml-2 rounded-md bg-[#4ade80] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
+              <span className="relative z-10 ml-2 rounded-md bg-[#4ade80] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
                 Paid
               </span>
             )}
-            {item.external && <ExternalLinkIcon className="ml-2 size-4" />}
+            {item.external && (
+              <ExternalLinkIcon className="relative z-10 ml-2 size-4" />
+            )}
           </Link>
         ) : (
           <span
             key={index}
             className={cn(
-              "flex w-full cursor-not-allowed items-center rounded-md p-2 text-muted-foreground hover:underline",
+              "flex w-full cursor-not-allowed items-center rounded-md p-2 text-muted-foreground",
               item.disabled && "cursor-not-allowed opacity-60",
             )}
           >


### PR DESCRIPTION
- adding the following active animation on the sidebar nav menu items 
- removing the underline from the disabled items

![animated-sidebar](https://github.com/user-attachments/assets/a74f8ae5-a014-46a3-a89c-bd48bafbadee)
