### PR TITLE
Changed typo in animated-grid-pattern.tsx

### DIFF
--- a/registry/components/magicui/animated-grid-pattern.tsx
+++ b/registry/components/magicui/animated-grid-pattern.tsx
@@ -18,7 +18,7 @@ interface GridPatternProps {
   repeatDelay?: number;
 }
 
-export function GridPattern({
+export function AnimatedGridPattern({
   width = 40,
   height = 40,
   x = -1,
@@ -147,4 +147,4 @@ export function GridPattern({
   );
 }
 
-export default GridPattern;
+export default AnimatedGridPattern;


### PR DESCRIPTION
Fixed Typo:

Example code in Animated Grid Pattern component uses < AnimatedGridPattern /> but animated-grid-pattern.tsx exports function with the name GridPattern.

Example code on live site 👇
![image](https://github.com/user-attachments/assets/db6543c2-3ec1-4079-b2c4-5cf02a8e9966)

Typo here 👇
![image](https://github.com/user-attachments/assets/b43d2660-524a-406c-9adc-1bf7e10c5bb8)
