### PR TITLE
Fix: GridPatternProps typing by replacing any with specific types

### DIFF
--- a/registry/components/magicui/grid-pattern.tsx
+++ b/registry/components/magicui/grid-pattern.tsx
@@ -3,14 +3,14 @@ import { useId } from "react";
 import { cn } from "@/lib/utils";
 
 interface GridPatternProps {
-  width?: any;
-  height?: any;
-  x?: any;
-  y?: any;
+  width?: number;
+  height?: number;
+  x?: number;
+  y?: number;
   squares?: Array<[x: number, y: number]>;
-  strokeDasharray?: any;
+  strokeDasharray?: number;
   className?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export function GridPattern({


### PR DESCRIPTION
This PR improves the type safety of the `GridPatternProps` interface by replacing `any` with more specific types. This change enhances code readability, maintainability, and reduces potential errors caused by the use of `any`.

**Key changes:**  
- Replaced `any` with more specific types in the `GridPatternProps` interface:
  - `width`: `number` (optional)
  - `height`: `number` (optional)
  - `x`: `number` (optional)
  - `y`: `number` (optional)
  - `strokeDasharray`: `number` (optional)
  - `[key: string]: unknown` – for additional unknown fields.

**Impact:**  
This change helps prevent errors in build, where improper typing (e.g., using `any`) can cause issues during build or deployment.

**Build Error Example:**
Here is a screenshot of the error encountered during the build on Vercel before applying these changes:

![failed to compil grid pattern](https://github.com/user-attachments/assets/ff399a47-ed0d-4146-b2aa-c31344366346)

