### PR TITLE
fix: ripple component tailwind order problem

### DIFF
--- a/registry/default/magicui/ripple.tsx
+++ b/registry/default/magicui/ripple.tsx
@@ -32,7 +32,7 @@ const Ripple = React.memo(function Ripple({
         return (
           <div
             key={i}
-            className={`absolute animate-ripple rounded-full bg-foreground/25 shadow-xl border [--i:${i}]`}
+            className={`[--i: absolute animate-ripple rounded-full border bg-foreground/25 shadow-xl${i}]`}
             style={
               {
                 width: `${size}px`,


### PR DESCRIPTION
A tailwind order issue in the `ripple.tsx` file was causing an error warning. I fixed that in the PR.