### PR TITLE
Fix/grid pattern type

### DIFF
--- a/registry/default/magicui/grid-pattern.tsx
+++ b/registry/default/magicui/grid-pattern.tsx
@@ -8,7 +8,7 @@ interface GridPatternProps {
   x?: number;
   y?: number;
   squares?: Array<[x: number, y: number]>;
-  strokeDasharray?: number;
+  strokeDasharray?: string;
   className?: string;
   [key: string]: unknown;
 }
@@ -18,7 +18,7 @@ export function GridPattern({
   height = 40,
   x = -1,
   y = -1,
-  strokeDasharray = 0,
+  strokeDasharray = "0",
   squares,
   className,
   ...props

--- a/registry/default/magicui/grid-pattern.tsx
+++ b/registry/default/magicui/grid-pattern.tsx
@@ -3,14 +3,14 @@ import { useId } from "react";
 import { cn } from "@/lib/utils";
 
 interface GridPatternProps {
-  width?: any;
-  height?: any;
-  x?: any;
-  y?: any;
+  width?: number;
+  height?: number;
+  x?: number;
+  y?: number;
   squares?: Array<[x: number, y: number]>;
-  strokeDasharray?: any;
+  strokeDasharray?: number;
   className?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export function GridPattern({


### PR DESCRIPTION
This PR improves the type safety of the `GridPatternProps` interface by replacing `any` with more specific types. This change enhances code readability, maintainability, and reduces potential errors caused by the use of `any`.

**Key changes:**  
- Replaced `any` with more specific types in the `GridPatternProps` interface:
  - `width`: `number` (optional)
  - `height`: `number` (optional)
  - `x`: `number` (optional)
  - `y`: `number` (optional)
  - `strokeDasharray`: `string` (optional)
  - `[key: string]: unknown` – for additional unknown fields.

**Impact:**  
This change helps prevent errors in build, where improper typing (e.g., using `any`) can cause issues during build or deployment.

**Build Error Example:**
Here is a screenshot of the error encountered during the build on Vercel before applying these changes:

![failed to compil grid pattern](https://github.com/user-attachments/assets/ff399a47-ed0d-4146-b2aa-c31344366346)