### PR TITLE
Add motion button props to shiny button

### DIFF
--- a/registry/default/magicui/shiny-button.tsx
+++ b/registry/default/magicui/shiny-button.tsx
@@ -43,7 +43,7 @@ const ShinyButton = React.forwardRef<HTMLButtonElement, ShinyButtonProps>(
         {...props}
         className={cn(
           "relative rounded-lg px-6 py-2 font-medium backdrop-blur-xl transition-shadow duration-300 ease-in-out hover:shadow dark:bg-[radial-gradient(circle_at_50%_0%,hsl(var(--primary)/10%)_0%,transparent_60%)] dark:hover:shadow-[0_0_20px_hsl(var(--primary)/10%)]",
-          className
+          className,
         )}
       >
         <span
@@ -64,7 +64,7 @@ const ShinyButton = React.forwardRef<HTMLButtonElement, ShinyButtonProps>(
         ></span>
       </motion.button>
     );
-  }
+  },
 );
 
 ShinyButton.displayName = "ShinyButton";

--- a/registry/default/magicui/shiny-button.tsx
+++ b/registry/default/magicui/shiny-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { motion, type AnimationProps } from "framer-motion";
+import { motion, type AnimationProps, type HTMLMotionProps } from "framer-motion";
 
 import { cn } from "@/lib/utils";
 
@@ -25,7 +25,7 @@ const animationProps = {
     },
   },
 } as AnimationProps;
-interface ShinyButtonProps {
+interface ShinyButtonProps extends HTMLMotionProps<"button"> {
   children: React.ReactNode;
   className?: string;
 }

--- a/registry/default/magicui/shiny-button.tsx
+++ b/registry/default/magicui/shiny-button.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import React from "react";
-import { motion, type AnimationProps, type HTMLMotionProps } from "framer-motion";
-
+import {
+  motion,
+  type AnimationProps,
+  type HTMLMotionProps,
+} from "framer-motion";
 import { cn } from "@/lib/utils";
 
 const animationProps = {
@@ -25,38 +28,45 @@ const animationProps = {
     },
   },
 } as AnimationProps;
+
 interface ShinyButtonProps extends HTMLMotionProps<"button"> {
   children: React.ReactNode;
   className?: string;
 }
-const ShinyButton = ({ children, className, ...props }: ShinyButtonProps) => {
-  return (
-    <motion.button
-      {...animationProps}
-      {...props}
-      className={cn(
-        "relative rounded-lg px-6 py-2 font-medium backdrop-blur-xl transition-shadow duration-300 ease-in-out hover:shadow dark:bg-[radial-gradient(circle_at_50%_0%,hsl(var(--primary)/10%)_0%,transparent_60%)] dark:hover:shadow-[0_0_20px_hsl(var(--primary)/10%)]",
-        className,
-      )}
-    >
-      <span
-        className="relative block size-full text-sm uppercase tracking-wide text-[rgb(0,0,0,65%)] dark:font-light dark:text-[rgb(255,255,255,90%)]"
-        style={{
-          maskImage:
-            "linear-gradient(-75deg,hsl(var(--primary)) calc(var(--x) + 20%),transparent calc(var(--x) + 30%),hsl(var(--primary)) calc(var(--x) + 100%))",
-        }}
+
+const ShinyButton = React.forwardRef<HTMLButtonElement, ShinyButtonProps>(
+  ({ children, className, ...props }, ref) => {
+    return (
+      <motion.button
+        ref={ref}
+        {...animationProps}
+        {...props}
+        className={cn(
+          "relative rounded-lg px-6 py-2 font-medium backdrop-blur-xl transition-shadow duration-300 ease-in-out hover:shadow dark:bg-[radial-gradient(circle_at_50%_0%,hsl(var(--primary)/10%)_0%,transparent_60%)] dark:hover:shadow-[0_0_20px_hsl(var(--primary)/10%)]",
+          className
+        )}
       >
-        {children}
-      </span>
-      <span
-        style={{
-          mask: "linear-gradient(rgb(0,0,0), rgb(0,0,0)) content-box,linear-gradient(rgb(0,0,0), rgb(0,0,0))",
-          maskComposite: "exclude",
-        }}
-        className="absolute inset-0 z-10 block rounded-[inherit] bg-[linear-gradient(-75deg,hsl(var(--primary)/10%)_calc(var(--x)+20%),hsl(var(--primary)/50%)_calc(var(--x)+25%),hsl(var(--primary)/10%)_calc(var(--x)+100%))] p-px"
-      ></span>
-    </motion.button>
-  );
-};
+        <span
+          className="relative block size-full text-sm uppercase tracking-wide text-[rgb(0,0,0,65%)] dark:font-light dark:text-[rgb(255,255,255,90%)]"
+          style={{
+            maskImage:
+              "linear-gradient(-75deg,hsl(var(--primary)) calc(var(--x) + 20%),transparent calc(var(--x) + 30%),hsl(var(--primary)) calc(var(--x) + 100%))",
+          }}
+        >
+          {children}
+        </span>
+        <span
+          style={{
+            mask: "linear-gradient(rgb(0,0,0), rgb(0,0,0)) content-box,linear-gradient(rgb(0,0,0), rgb(0,0,0))",
+            maskComposite: "exclude",
+          }}
+          className="absolute inset-0 z-10 block rounded-[inherit] bg-[linear-gradient(-75deg,hsl(var(--primary)/10%)_calc(var(--x)+20%),hsl(var(--primary)/50%)_calc(var(--x)+25%),hsl(var(--primary)/10%)_calc(var(--x)+100%))] p-px"
+        ></span>
+      </motion.button>
+    );
+  }
+);
+
+ShinyButton.displayName = "ShinyButton";
 
 export default ShinyButton;


### PR DESCRIPTION
Currently you cannot use the property `onClick` for `ShinyButton`. Since the rest of the props (`...props`) are passed to `motion.button`, I extended `ShinyButtonProps` with `HTMLMotionProps<"button">`.