### PR TITLE
fix: add pointer-events-none class to particles container

### DIFF
--- a/registry/default/magicui/particles.tsx
+++ b/registry/default/magicui/particles.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import React, { useEffect, useRef, useState } from "react";
 
 interface MousePosition {
@@ -269,7 +270,7 @@ const Particles: React.FC<ParticlesProps> = ({
   };
 
   return (
-    <div className={className} ref={canvasContainerRef} aria-hidden="true">
+    <div className={cn("pointer-events-none", className)} ref={canvasContainerRef} aria-hidden="true">
       <canvas ref={canvasRef} className="size-full" />
     </div>
   );


### PR DESCRIPTION
## What's Changed
Added pointer-events-none class to the main container div in the Particles component
This fixes the issue with carousel button interactions
## Why This Matters
The Particles component was unintentionally blocking mouse events on elements beneath it, particularly affecting carousel buttons. This simple fix allows click events to pass through to the underlying elements.

