### PR TITLE
Fix: Correct misspelled variable in Tailwind config for AnimatedShinyText component (#362)

### DIFF
--- a/content/docs/components/animated-shiny-text.mdx
+++ b/content/docs/components/animated-shiny-text.mdx
@@ -50,10 +50,10 @@ module.exports = {
       keyframes: {
         "shiny-text": {
           "0%, 90%, 100%": {
-            "background-position": "calc(-100% - var(--shimmer-width)) 0",
+            "background-position": "calc(-100% - var(--shiny-width)) 0",
           },
           "30%, 60%": {
-            "background-position": "calc(100% + var(--shimmer-width)) 0",
+            "background-position": "calc(100% + var(--shiny-width)) 0",
           },
         },
       },


### PR DESCRIPTION
This PR resolves issue #362, where the custom animation for the `AnimatedShinyText` component was not working due to a misspelled variable in the `tailwind.config.js` file in documentation.

Changes:
- Renamed the CSS variable `--shimmer-width` to `--shiny-width` in the `tailwind.config.js` to match the variable used in the `AnimatedShinyText` component.

Testing:
- Verified that the animation now works as expected after updating the variable.
- Ensured that the manual installation guide reflects the correct configuration.

Fixes #362