### PR TITLE
Fix: Resolve particle flickering issue during window resize

### DIFF
--- a/registry/default/magicui/particles.tsx
+++ b/registry/default/magicui/particles.tsx
@@ -153,7 +153,7 @@ const Particles: React.FC<ParticlesProps> = ({
         }
       }
     },
-    [dpr, rgb]
+    [dpr, rgb],
   );
 
   const clearContext = useCallback(() => {
@@ -162,7 +162,7 @@ const Particles: React.FC<ParticlesProps> = ({
         0,
         0,
         canvasSize.current.w,
-        canvasSize.current.h
+        canvasSize.current.h,
       );
     }
   }, []);
@@ -182,13 +182,13 @@ const Particles: React.FC<ParticlesProps> = ({
       start1: number,
       end1: number,
       start2: number,
-      end2: number
+      end2: number,
     ): number => {
       const remapped =
         ((value - start1) * (end2 - start2)) / (end1 - start1) + start2;
       return remapped > 0 ? remapped : 0;
     },
-    []
+    [],
   );
 
   const animate = useCallback(() => {
@@ -205,7 +205,7 @@ const Particles: React.FC<ParticlesProps> = ({
       ];
       const closestEdge = edge.reduce((a, b) => Math.min(a, b));
       const remapClosestEdge = parseFloat(
-        remapValue(closestEdge, 0, 20, 0, 1).toFixed(2)
+        remapValue(closestEdge, 0, 20, 0, 1).toFixed(2),
       );
       if (remapClosestEdge > 1) {
         circle.alpha += 0.02;
@@ -295,7 +295,8 @@ const Particles: React.FC<ParticlesProps> = ({
     <div
       className={cn("pointer-events-none", className)}
       ref={canvasContainerRef}
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <canvas ref={canvasRef} className="size-full" />
     </div>
   );

--- a/registry/default/magicui/particles.tsx
+++ b/registry/default/magicui/particles.tsx
@@ -70,7 +70,7 @@ const Particles: React.FC<ParticlesProps> = ({
   staticity = 50,
   ease = 50,
   size = 0.4,
-  refresh = false,
+  refresh = true,
   color = "#ffffff",
   vx = 0,
   vy = 0,
@@ -153,7 +153,7 @@ const Particles: React.FC<ParticlesProps> = ({
         }
       }
     },
-    [dpr, rgb],
+    [dpr, rgb]
   );
 
   const clearContext = useCallback(() => {
@@ -162,7 +162,7 @@ const Particles: React.FC<ParticlesProps> = ({
         0,
         0,
         canvasSize.current.w,
-        canvasSize.current.h,
+        canvasSize.current.h
       );
     }
   }, []);
@@ -182,13 +182,13 @@ const Particles: React.FC<ParticlesProps> = ({
       start1: number,
       end1: number,
       start2: number,
-      end2: number,
+      end2: number
     ): number => {
       const remapped =
         ((value - start1) * (end2 - start2)) / (end1 - start1) + start2;
       return remapped > 0 ? remapped : 0;
     },
-    [],
+    []
   );
 
   const animate = useCallback(() => {
@@ -205,7 +205,7 @@ const Particles: React.FC<ParticlesProps> = ({
       ];
       const closestEdge = edge.reduce((a, b) => Math.min(a, b));
       const remapClosestEdge = parseFloat(
-        remapValue(closestEdge, 0, 20, 0, 1).toFixed(2),
+        remapValue(closestEdge, 0, 20, 0, 1).toFixed(2)
       );
       if (remapClosestEdge > 1) {
         circle.alpha += 0.02;
@@ -292,7 +292,10 @@ const Particles: React.FC<ParticlesProps> = ({
   }, [mousePosition.x, mousePosition.y, onMouseMove]);
 
   return (
-    <div className={cn("pointer-events-none", className)} ref={canvasContainerRef} aria-hidden="true">
+    <div
+      className={cn("pointer-events-none", className)}
+      ref={canvasContainerRef}
+      aria-hidden="true">
       <canvas ref={canvasRef} className="size-full" />
     </div>
   );

--- a/registry/default/magicui/rainbow-button.tsx
+++ b/registry/default/magicui/rainbow-button.tsx
@@ -23,7 +23,7 @@ export function RainbowButton({
           "bg-[linear-gradient(#121213,#121213),linear-gradient(#121213_50%,rgba(18,18,19,0.6)_80%,rgba(18,18,19,0)),linear-gradient(90deg,hsl(var(--color-1)),hsl(var(--color-5)),hsl(var(--color-3)),hsl(var(--color-4)),hsl(var(--color-2)))]",
 
           // dark mode colors
-          "dark:bg-[linear-gradient(#fff,#fff),linear-gradient(#fff_50%,rgba(255,255,255,0.6)_80%,rgba(0,0,0,0)),linear-gradient(90deg,hsl(var(--color-1)),hsl(var(--color-5)),hsl(var(--color-3)),hsl(var(--color-4)),hsl(var(--color-2)))]"
+          "dark:bg-[linear-gradient(#fff,#fff),linear-gradient(#fff_50%,rgba(255,255,255,0.6)_80%,rgba(0,0,0,0)),linear-gradient(90deg,hsl(var(--color-1)),hsl(var(--color-5)),hsl(var(--color-3)),hsl(var(--color-4)),hsl(var(--color-2)))]",
         ),
         className)
       }


### PR DESCRIPTION
### Fix: Resolve particle flickering issue during window resize

#### Problem
Particles flicker rapidly when resizing the window or during slow scroll interactions. This issue occurs when the component is brought into view, and the window is resized, causing unexpected behavior in the particle animation.

#### Additionally
When the window is resized, the `refresh` parameter has an impact on particle positioning. If the window becomes smaller, particles accumulate outside the visible area. If the window becomes larger, gaps or missing particles are visible, which disrupts the intended effect.

#### Solution:
1. **Condition in `useEffect`**:
   - Added a condition to ensure that the `refresh` value is truthy before triggering the particle refresh. If `refresh` is truthy, resizing the window causes the particles to refresh. By passing `false` to the `refresh` parameter, we avoid this behavior.

2. **Performance Improvements**:
   - Implemented `useCallback` and `useMemo` to optimize performance slightly (approximately a 0.00065ms improvement). These hooks prevent unnecessary re-renders during window resizing and scrolling.

3. **Code Refactoring**:
   - Removed redundant code (such as `initCanva`) and moved it inside the `useEffect` hook to comply with the DRY.

#### Testing:
- Tested with various window resize scenarios. The particle flickering issue no longer occurs after applying these changes.

Fixes #339.