### PR TITLE
Fix OrbitingCircles size

### DIFF
--- a/registry/default/magicui/orbiting-circles.tsx
+++ b/registry/default/magicui/orbiting-circles.tsx
@@ -46,7 +46,7 @@ export default function OrbitingCircles({
           } as React.CSSProperties
         }
         className={cn(
-          "absolute flex size-full transform-gpu animate-orbit items-center justify-center rounded-full border bg-black/10 [animation-delay:calc(var(--delay)*1000ms)] dark:bg-white/10",
+          "absolute flex transform-gpu animate-orbit items-center justify-center rounded-full border bg-black/10 [animation-delay:calc(var(--delay)*1000ms)] dark:bg-white/10",
           { "[animation-direction:reverse]": reverse },
           className,
         )}


### PR DESCRIPTION
size-full overwrites the size of icon
<img width="231" alt="Screenshot 2024-10-10 at 17 01 36" src="https://github.com/user-attachments/assets/5f97701a-0a57-4da9-9124-276decfe9420">
