### PR TITLE
Memory leak (orphaned raf loop) fix: Cancelling animation frame in particles.tsx on rerender

### DIFF
--- a/registry/default/magicui/particles.tsx
+++ b/registry/default/magicui/particles.tsx
@@ -76,6 +76,7 @@ const Particles: React.FC<ParticlesProps> = ({
   const mouse = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
   const canvasSize = useRef<{ w: number; h: number }>({ w: 0, h: 0 });
   const dpr = typeof window !== "undefined" ? window.devicePixelRatio : 1;
+  const rafID = useRef<number | null>(null);
 
   useEffect(() => {
     if (canvasRef.current) {
@@ -86,6 +87,9 @@ const Particles: React.FC<ParticlesProps> = ({
     window.addEventListener("resize", initCanvas);
 
     return () => {
+      if (rafID.current != null) {
+        window.cancelAnimationFrame(rafID.current);
+      }
       window.removeEventListener("resize", initCanvas);
     };
   }, [color]);
@@ -266,7 +270,7 @@ const Particles: React.FC<ParticlesProps> = ({
         // update the circle position
       }
     });
-    window.requestAnimationFrame(animate);
+    rafID.current = window.requestAnimationFrame(animate);
   };
 
   return (


### PR DESCRIPTION
Without cancelling animation frame, you'll end up with orphaned animation frame loops running in the background when the component rerenders.

<img width="690" alt="image" src="https://github.com/user-attachments/assets/5ee16933-4804-4086-8cb2-f8c235026218">
