### PR TITLE
Fixing linter issue: dock.tsx

### DIFF
--- a/registry/default/magicui/dock.tsx
+++ b/registry/default/magicui/dock.tsx
@@ -96,13 +96,13 @@ const DockIcon = ({
     return val - bounds.x - bounds.width / 2;
   });
 
-  let widthSync = useTransform(
+  const widthSync = useTransform(
     distanceCalc,
     [-distance, 0, distance],
     [40, magnification, 40],
   );
 
-  let width = useSpring(widthSync, {
+  const width = useSpring(widthSync, {
     mass: 0.1,
     stiffness: 150,
     damping: 12,


### PR DESCRIPTION
Resolving the build error in Nextjs 15 ESLint configuration:

Local Build:
<img width="1512" alt="Screenshot 2024-11-01 at 5 37 03 PM" src="https://github.com/user-attachments/assets/03ef3542-63c0-4785-99ed-02d89bc97a25">

Vercel Build:
<img width="1205" alt="Screenshot 2024-11-01 at 5 38 27 PM" src="https://github.com/user-attachments/assets/63ec6856-de0b-431a-b7ae-14ccbdafa10f">
