### PR TITLE
Making the flickering grid example fade out

### DIFF
--- a/registry/default/example/flickering-grid-rounded-demo.tsx
+++ b/registry/default/example/flickering-grid-rounded-demo.tsx
@@ -3,16 +3,16 @@ import FlickeringGrid from "@/registry/default/magicui/flickering-grid";
 export default function FlickeringGridRoundedDemo() {
   return (
     <div className="relative size-[600px] rounded-lg w-full bg-background overflow-hidden border">
-      <FlickeringGrid
-        className="z-0 absolute inset-0 [mask:radial-gradient(circle_at_center,#fff_300px,transparent_0)]"
-        squareSize={4}
-        gridGap={6}
-        color="#60A5FA"
-        maxOpacity={0.5}
-        flickerChance={0.1}
-        height={800}
-        width={800}
-      />
+        <FlickeringGrid
+          className="z-0 relative inset-0 [mask-image:radial-gradient(450px_circle_at_center,white,transparent)]"
+          squareSize={4}
+          gridGap={6}
+          color="#60A5FA"
+          maxOpacity={0.5}
+          flickerChance={0.1}
+          height={800}
+          width={800}
+        />
     </div>
   );
 }


### PR DESCRIPTION
The flickering grid example would look a lot better if it faded out instead of cutting off at the edges of the circle. I used the code from the dot background to fade the background out.