### PR TITLE
fix(hero-video-dialog): resolve dialog display issue while keeping keep gradient mask

### DIFF
--- a/content/docs/components/hero-video-dialog.mdx
+++ b/content/docs/components/hero-video-dialog.mdx
@@ -54,6 +54,7 @@ npx shadcn@latest add "https://magicui.design/r/hero-video-dialog"
 | videoSrc       | string | URL of the video to be played    | -                 |
 | thumbnailSrc   | string | URL of the thumbnail image       | -                 |
 | thumbnailAlt   | string | Alt text for the thumbnail image | "Video thumbnail" |
+| maskGradient   | string | CSS gradient for the mask        | -                 |
 
 ## Animation Styles
 

--- a/registry/default/magicui/hero-video-dialog.tsx
+++ b/registry/default/magicui/hero-video-dialog.tsx
@@ -22,6 +22,7 @@ interface HeroVideoProps {
   thumbnailSrc: string;
   thumbnailAlt?: string;
   className?: string;
+  maskGradient?: string;
 }
 
 const animationVariants = {
@@ -73,6 +74,7 @@ export default function HeroVideoDialog({
   thumbnailSrc,
   thumbnailAlt = "Video thumbnail",
   className,
+  maskGradient,
 }: HeroVideoProps) {
   const [isVideoOpen, setIsVideoOpen] = useState(false);
   const selectedAnimation = animationVariants[animationStyle];
@@ -80,7 +82,7 @@ export default function HeroVideoDialog({
   return (
     <div className={cn("relative", className)}>
       <div
-        className="relative cursor-pointer group"
+        className={cn("relative cursor-pointer group", maskGradient)}
         onClick={() => setIsVideoOpen(true)}
       >
         <img


### PR DESCRIPTION
The issue #385 showed a broken effect in the "Hero Video Dialog".

After further investigation, I found that **the mask linear gradient causes the issue** when appended to the className of the parent div element.

To solve this issue, I added a **maskGradient** attribute that takes a mask CSS gradient as input, and adds it to the second div parent element which makes the dialog work perfectly despite having the gradient.

Screenshots after code update:

![89102](https://github.com/user-attachments/assets/836491c7-1977-4776-983e-e31f129c7f81)

![31003](https://github.com/user-attachments/assets/c383feaa-f8df-4cce-924c-4fb6db94e8b1) 