### PR TITLE
perf(seo): change motion.h1 to motion.span

### DIFF
--- a/registry/default/magicui/hyper-text.tsx
+++ b/registry/default/magicui/hyper-text.tsx
@@ -75,7 +75,7 @@ export default function HyperText({
     >
       <AnimatePresence mode="wait">
         {displayText.map((letter, i) => (
-          <motion.h1
+          <motion.span
             key={i}
             className={cn("font-mono", letter === " " ? "w-3" : "", className)}
             {...framerProps}


### PR DESCRIPTION
There should be only one H1 heading on a single page.