### PR TITLE
feat: add startValue prop to number-ticker component

### DIFF
--- a/registry/default/magicui/number-ticker.tsx
+++ b/registry/default/magicui/number-ticker.tsx
@@ -7,19 +7,21 @@ import { cn } from "@/lib/utils";
 
 export default function NumberTicker({
   value,
+  startValue = 0,
   direction = "up",
   delay = 0,
   className,
   decimalPlaces = 0,
 }: {
   value: number;
+  startValue?: number;
   direction?: "up" | "down";
   className?: string;
-  delay?: number; // delay in s
+  delay?: number; // delay in seconds
   decimalPlaces?: number;
 }) {
   const ref = useRef<HTMLSpanElement>(null);
-  const motionValue = useMotionValue(direction === "down" ? value : 0);
+  const motionValue = useMotionValue(direction === "down" ? value : startValue);
   const springValue = useSpring(motionValue, {
     damping: 60,
     stiffness: 100,
@@ -27,11 +29,12 @@ export default function NumberTicker({
   const isInView = useInView(ref, { once: true, margin: "0px" });
 
   useEffect(() => {
-    isInView &&
+    if (isInView) {
       setTimeout(() => {
-        motionValue.set(direction === "down" ? 0 : value);
+        motionValue.set(direction === "down" ? startValue : value);
       }, delay * 1000);
-  }, [motionValue, isInView, delay, value, direction]);
+    }
+  }, [motionValue, isInView, delay, value, direction, startValue]);
 
   useEffect(
     () =>
@@ -43,14 +46,14 @@ export default function NumberTicker({
           }).format(Number(latest.toFixed(decimalPlaces)));
         }
       }),
-    [springValue, decimalPlaces],
+    [springValue, decimalPlaces]
   );
 
   return (
     <span
       className={cn(
-        "inline-block tabular-nums text-black dark:text-white tracking-wider",
-        className,
+        "inline-block tabular-nums tracking-wider text-black dark:text-white",
+        className
       )}
       ref={ref}
     />


### PR DESCRIPTION
## Pull Request: Add startValue Prop to NumberTicker Component

This PR introduces a new startValue prop for the NumberTicker component. The startValue prop allows users to set an initial value for the number displayed by the component.


Demo video

https://github.com/user-attachments/assets/3f8f0f38-5009-4976-ace9-511c487b475d

Related Issue
Closes #426
