### PR TITLE
Update animated-beam.tsx

### DIFF
--- a/registry/default/magicui/animated-beam.tsx
+++ b/registry/default/magicui/animated-beam.tsx
@@ -7,9 +7,9 @@ import { cn } from "@/lib/utils";
 
 export interface AnimatedBeamProps {
   className?: string;
-  containerRef: RefObject<HTMLElement>; // Container ref
-  fromRef: RefObject<HTMLElement>;
-  toRef: RefObject<HTMLElement>;
+  containerRef: RefObject<HTMLElement | null>; // Container ref
+  fromRef: RefObject<HTMLElement | null>;
+  toRef: RefObject<HTMLElement | null>;
   curvature?: number;
   reverse?: boolean;
   pathColor?: string;


### PR DESCRIPTION
Fix error:
Type 'RefObject<HTMLDivElement | null>' is not assignable to type 'RefObject<HTMLElement>'.
  Type 'HTMLDivElement | null' is not assignable to type 'HTMLElement'.
    Type 'null' is not assignable to type 'HTMLElement'.ts(2322)

This is a fix for a reported issue: https://github.com/magicuidesign/magicui/issues/433