### PR TITLE
fix: gave the hypertext animation to start when in View

### DIFF
--- a/registry/default/magicui/hyper-text.tsx
+++ b/registry/default/magicui/hyper-text.tsx
@@ -78,7 +78,7 @@ export default function HyperText({
           observer.disconnect();
         }
       },
-      { threshold: 0.1 },
+      { threshold: 0.1, rootMargin: "-30% 0px -30% 0px" },
     );
 
     if (elementRef.current) {
@@ -123,7 +123,7 @@ export default function HyperText({
       onMouseEnter={handleAnimationTrigger}
       {...props}
     >
-      <AnimatePresence mode="wait">
+      <AnimatePresence>
         {displayText.map((letter, index) => (
           <motion.span
             key={index}


### PR DESCRIPTION
Added some `rootMargin: "-30% 0px -30% 0px"` to trigger the animation when the text comes a little bit close to the middle.