### PR TITLE
fix: fixing the morphing text to work on firefox too

### DIFF
--- a/registry/default/magicui/morphing-text.tsx
+++ b/registry/default/magicui/morphing-text.tsx
@@ -110,7 +110,11 @@ const Texts: React.FC<Pick<MorphingTextProps, "texts">> = ({ texts }) => {
 };
 
 const SvgFilters: React.FC = () => (
-  <svg id="filters" className="hidden" preserveAspectRatio="xMidYMid slice">
+  <svg
+    id="filters"
+    className="fixed h-0 w-0"
+    preserveAspectRatio="xMidYMid slice"
+  >
     <defs>
       <filter id="threshold">
         <feColorMatrix


### PR DESCRIPTION
I fixed the `svgFilters` which should resolve the inconsistent animation on Firefox.