### PR TITLE
add: ID for icon cloud to avoid hydration errors

### DIFF
--- a/registry/default/magicui/icon-cloud.tsx
+++ b/registry/default/magicui/icon-cloud.tsx
@@ -17,6 +17,7 @@ export type DynamicCloudProps = {
 };
 
 export const cloudProps: Omit<ICloud, "children"> = {
+  id: "icon-cloud",
   containerProps: {
     style: {
       display: "flex",


### PR DESCRIPTION
When using the Icon Cloud component in an SSR framework such as NextJS, the default behaviour of the upstream react-icon-cloud dependency is to use a UUID for the canvas ID. This is a problem, as the UUID will change between the server and the client and cause a hydration error. Since the upstream dependency also allows for changing the ID with the `id` prop, I think that having that filled as the default for this component and therefore alleviating the issue above will be better, as it is safe to assume that most users of MagicUI will most likey be using some kind of SSR framework.