### PR TITLE
fix(particles-demo): remove extra character from demo

### DIFF
--- a/registry/default/example/particles-demo.tsx
+++ b/registry/default/example/particles-demo.tsx
@@ -18,7 +18,6 @@ export default function ParticlesDemo() {
       <span className="pointer-events-none z-10 whitespace-pre-wrap text-center text-8xl font-semibold leading-none">
         Particles
       </span>
-      q
       <Particles
         className="absolute inset-0 z-0"
         quantity={100}


### PR DESCRIPTION
I noticed an extra character in the preview of the [particles demo](https://magicui.design/docs/components/particles). This PR removes the extra char


#### Screenshot for reference 

<img width="978" alt="Screenshot 2024-12-28 at 11 14 48 AM" src="https://github.com/user-attachments/assets/7d11948a-3d3f-4450-8747-a32a090f6015" />
