### PR TITLE
fix(icon-cloud): not rendering icon color

### DIFF
--- a/content/docs/components/icon-cloud.mdx
+++ b/content/docs/components/icon-cloud.mdx
@@ -94,7 +94,7 @@ Used to create a tag for the Cloud component
 
 ### fetchSimpleIcons
 
-Used when you cant statically import simple icons during built time. Calling this will use `fetch` to get icons for each provided slug.
+Used when you cant statically import simple icons during build time. Calling this will use `fetch` to get icons for each provided slug.
 | Prop | type | default | description |
 |:----------------:|:-----------------------------------------------:|:---------:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------:|
 | slugs | string[] | | Slugs to fetch svgs and colors for. The return icons may be passed to renderSimpleIcon |

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-day-picker": "^8.9.1",
     "react-dom": "18.3.1",
     "react-hook-form": "^7.50.1",
-    "react-icon-cloud": "^4.1.4",
+    "react-icon-cloud": "^4.1.6",
     "react-tweet": "^3.2.1",
     "schema-dts": "^1.1.2",
     "sonner": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,8 +147,8 @@ importers:
         specifier: ^7.50.1
         version: 7.50.1(react@18.3.1)
       react-icon-cloud:
-        specifier: ^4.1.4
-        version: 4.1.4(react@18.3.1)
+        specifier: ^4.1.6
+        version: 4.1.6(react@18.3.1)
       react-tweet:
         specifier: ^3.2.1
         version: 3.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4428,9 +4428,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18
 
-  react-icon-cloud@4.1.4:
-    resolution: {integrity: sha512-hc8yGNU98V6ObPdeNIt75M016xGMxbTWqB4l6exo1uwE5bvFU095unMbX2K3YBKYhGKEV3c7fSmq3jD3cRWX+A==}
-    engines: {node: '>=10'}
+  react-icon-cloud@4.1.6:
+    resolution: {integrity: sha512-M19XUQjGpQQZD3kVQ8YxbMhM33Yx4vQFUPEurN2CajrzzUcoyiPqJnKDgCCkkL4nd3hemB4PgK2LVsHwEkFKdg==}
+    engines: {node: '>=22'}
     peerDependencies:
       react: '>=16'
 
@@ -7830,7 +7830,7 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.3.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.1)
       eslint-plugin-react: 7.33.2(eslint@8.57.1)
@@ -7853,12 +7853,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.1
       eslint: 8.57.1
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
@@ -7870,14 +7870,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.3.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7891,7 +7891,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       hasown: 2.0.1
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -10043,7 +10043,7 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  react-icon-cloud@4.1.4(react@18.3.1):
+  react-icon-cloud@4.1.6(react@18.3.1):
     dependencies:
       '@csstools/convert-colors': 2.0.0
       react: 18.3.1


### PR DESCRIPTION
# issue
1. #465
    -  the icon cloud suddenly stoped rendering color
1. small typo in icon cloud docs

# proposed fix
1. bump react-icon-cloud [from 4.1.4 to latest 4.1.6](https://github.com/teaguestockwell/react-icon-cloud/releases)
    - @EngenMe [change in 4.1.5 fixed the colors](https://github.com/teaguestockwell/react-icon-cloud/pull/17)
    - this change in 4.1.6 [prevent future breaks by locking to a specific version of hosted icon paths & colors](https://github.com/teaguestockwell/react-icon-cloud/commit/b29d8e59346c67708ff30611f62a134b2b2d8ca6)
1. fixed typo
    
# how verified

 ## before
<img width="1512" alt="cloud-before" src="https://github.com/user-attachments/assets/a9e43481-32fa-4b67-9a96-d8155369a7c8" />

## after
<img width="1512" alt="cloud-after" src="https://github.com/user-attachments/assets/e887ad0f-65ba-45ae-8ea6-7b1d5af57c22" />