### PR TITLE
fix: mobile sidebar menu active state

### DIFF
--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import Link, { LinkProps } from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import posthog from "posthog-js";
 
 import { docsConfig } from "@/config/docs";
@@ -136,6 +136,8 @@ function MobileLink({
   ...props
 }: MobileLinkProps) {
   const router = useRouter();
+  const pathname = usePathname();
+  const isActive = pathname === href;
   return (
     <SheetClose asChild>
       <Link
@@ -144,7 +146,13 @@ function MobileLink({
           router.push(href.toString());
           onOpenChange?.(false);
         }}
-        className={cn(className)}
+        className={cn(
+          className,
+          "text-[15px]",
+          isActive
+            ? "font-medium text-primary underline underline-offset-4"
+            : "",
+        )}
         {...props}
       >
         {children}

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -71,7 +71,7 @@ export function MobileNav() {
                   <MobileLink key={item.href} href={item.href}>
                     {item.title}
                   </MobileLink>
-                )
+                ),
             )}
           </div>
           <div className="flex flex-col gap-y-2">
@@ -86,7 +86,7 @@ export function MobileNav() {
                       onClick={() => item.event && posthog.capture(item.event)}
                       className={cn(
                         "text-muted-foreground",
-                        item.disabled && "cursor-not-allowed opacity-60"
+                        item.disabled && "cursor-not-allowed opacity-60",
                       )}
                     >
                       {item.title}
@@ -101,7 +101,7 @@ export function MobileNav() {
                       key={index}
                       className={cn(
                         "text-muted-foreground",
-                        item.disabled && "cursor-not-allowed opacity-60"
+                        item.disabled && "cursor-not-allowed opacity-60",
                       )}
                     >
                       {item.title}
@@ -111,7 +111,7 @@ export function MobileNav() {
                         </span>
                       )}
                     </span>
-                  )
+                  ),
                 )}
               </div>
             ))}
@@ -151,7 +151,7 @@ function MobileLink({
           "p-1 pl-2.5 text-[15px]",
           isActive
             ? "rounded-r-md border-l-2 border-primary/70 bg-secondary font-medium text-primary"
-            : ""
+            : "",
         )}
         {...props}
       >

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import * as React from "react";
 import Link, { LinkProps } from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import posthog from "posthog-js";
+import * as React from "react";
 
-import { docsConfig } from "@/config/docs";
-import { siteConfig } from "@/config/site";
-import { cn } from "@/lib/utils";
+import { Icons } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
@@ -16,7 +14,9 @@ import {
   SheetContent,
   SheetTrigger,
 } from "@/components/ui/sheet";
-import { Icons } from "@/components/icons";
+import { docsConfig } from "@/config/docs";
+import { siteConfig } from "@/config/site";
+import { cn } from "@/lib/utils";
 
 export function MobileNav() {
   return (
@@ -63,7 +63,7 @@ export function MobileNav() {
           <Icons.logo className="mr-2 size-4" />
           <span className="font-bold">{siteConfig.name}</span>
         </MobileLink>
-        <ScrollArea className="my-4 h-[calc(100vh-8rem)] pb-10 pl-6">
+        <ScrollArea className="my-4 h-[calc(100vh-6rem)]">
           <div className="flex flex-col space-y-3">
             {docsConfig.mainNav?.map(
               (item) =>

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -58,25 +58,25 @@ export function MobileNav() {
           <span className="sr-only">Toggle Menu</span>
         </Button>
       </SheetTrigger>
-      <SheetContent side="left" className="pr-0">
+      <SheetContent side="left">
         <MobileLink href="/" className="flex items-center">
           <Icons.logo className="mr-2 size-4" />
           <span className="font-bold">{siteConfig.name}</span>
         </MobileLink>
         <ScrollArea className="my-4 h-[calc(100vh-6rem)]">
-          <div className="flex flex-col space-y-3">
+          <div className="flex flex-col space-y-1.5">
             {docsConfig.mainNav?.map(
               (item) =>
                 item.href && (
                   <MobileLink key={item.href} href={item.href}>
                     {item.title}
                   </MobileLink>
-                ),
+                )
             )}
           </div>
-          <div className="flex flex-col space-y-2">
+          <div className="flex flex-col gap-y-2">
             {docsConfig.sidebarNav.map((item, index) => (
-              <div key={index} className="flex flex-col space-y-3 pt-6">
+              <div key={index} className="flex flex-col gap-y-1.5 pt-6">
                 <h4 className="font-medium">{item.title}</h4>
                 {item.items?.map((item) =>
                   !item.disabled && item.href ? (
@@ -86,7 +86,7 @@ export function MobileNav() {
                       onClick={() => item.event && posthog.capture(item.event)}
                       className={cn(
                         "text-muted-foreground",
-                        item.disabled && "cursor-not-allowed opacity-60",
+                        item.disabled && "cursor-not-allowed opacity-60"
                       )}
                     >
                       {item.title}
@@ -101,7 +101,7 @@ export function MobileNav() {
                       key={index}
                       className={cn(
                         "text-muted-foreground",
-                        item.disabled && "cursor-not-allowed opacity-60",
+                        item.disabled && "cursor-not-allowed opacity-60"
                       )}
                     >
                       {item.title}
@@ -111,7 +111,7 @@ export function MobileNav() {
                         </span>
                       )}
                     </span>
-                  ),
+                  )
                 )}
               </div>
             ))}
@@ -148,10 +148,10 @@ function MobileLink({
         }}
         className={cn(
           className,
-          "text-[15px]",
+          "p-1 pl-2.5 text-[15px]",
           isActive
-            ? "font-medium text-primary underline underline-offset-4"
-            : "",
+            ? "rounded-r-md border-l-2 border-primary/70 bg-secondary font-medium text-primary"
+            : ""
         )}
         {...props}
       >


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2b60e3ea-4b57-4915-922c-73df86b86d97)

Adding an `active` state to the mobile navigation menu items and changing the font size to an arbitrary value of 15px instead of the default. I think the default size looks a bit too big, and 15px feels more balanced and justified.