### PR TITLE
fix: number ticker flickering and adding startValue props

### DIFF
--- a/content/docs/components/number-ticker.mdx
+++ b/content/docs/components/number-ticker.mdx
@@ -52,6 +52,7 @@ npx shadcn@latest add "https://magicui.design/r/number-ticker"
 | Prop          | Type       | Description                          | Default |
 | ------------- | ---------- | ------------------------------------ | ------- |
 | value         | int        | The value to count to                | 0       |
+| startValue    | int        | The value to start counting from     | 0       |
 | direction     | up \| down | The direction to count in            | up      |
 | delay         | number     | The delay before counting            | 0       |
 | decimalPlaces | number     | The number of decimal places to show | 0       |

--- a/registry/default/magicui/number-ticker.tsx
+++ b/registry/default/magicui/number-ticker.tsx
@@ -11,15 +11,17 @@ export default function NumberTicker({
   delay = 0,
   className,
   decimalPlaces = 0,
+  startValue = 0,
 }: {
   value: number;
   direction?: "up" | "down";
   className?: string;
   delay?: number; // delay in s
   decimalPlaces?: number;
+  startValue?: number;
 }) {
   const ref = useRef<HTMLSpanElement>(null);
-  const motionValue = useMotionValue(direction === "down" ? value : 0);
+  const motionValue = useMotionValue(direction === "down" ? value : startValue);
   const springValue = useSpring(motionValue, {
     damping: 60,
     stiffness: 100,
@@ -29,9 +31,9 @@ export default function NumberTicker({
   useEffect(() => {
     isInView &&
       setTimeout(() => {
-        motionValue.set(direction === "down" ? 0 : value);
+        motionValue.set(direction === "down" ? startValue : value);
       }, delay * 1000);
-  }, [motionValue, isInView, delay, value, direction]);
+  }, [motionValue, isInView, delay, value, direction, startValue]);
 
   useEffect(
     () =>
@@ -53,6 +55,8 @@ export default function NumberTicker({
         className,
       )}
       ref={ref}
-    />
+    >
+      {startValue}
+    </span>
   );
 }


### PR DESCRIPTION
I think it's flickering due script that generate number isn't ready yet, I also add startValue props just in case we don't want it to count from zero.

before:

https://github.com/user-attachments/assets/780ec3f5-7104-4a02-8b7e-efd8500639f7

After:

https://github.com/user-attachments/assets/3add02f9-6e14-466e-96e1-90174462662e



