### PR TITLE
fix: comment out export default replacement in rehype-component

### DIFF
--- a/lib/rehype-component.ts
+++ b/lib/rehype-component.ts
@@ -52,7 +52,7 @@ export function rehypeComponent() {
               `@/registry/${style.name}/`,
               "@/components/",
             );
-            source = source.replaceAll("export default", "export");
+            // source = source.replaceAll("export default", "export");
 
             // Add code as children so that rehype can take over at build time.
             node.children?.push(


### PR DESCRIPTION
fixing some components have the same export in manual.

<img width="870" alt="image" src="https://github.com/user-attachments/assets/42948876-4030-4a59-8cd8-344e7799d9bb" />

<img width="897" alt="image" src="https://github.com/user-attachments/assets/bcbb3911-3347-4061-aa8c-d9f178c01779" />
