### PR TITLE
fix: update contribute docs with correct cli example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ published: true
 <TabsContent value="cli">
 
 ```bash
-npx magicui-cli add example-component
+npx shadcn@latest add "https://magicui.design/r/example-component"
 ```
 
 </TabsContent>
@@ -136,15 +136,11 @@ npx magicui-cli add example-component
 
 <ComponentSource name="example-component" />
 
-<Step>Update the import paths to match your project setup.</Step>
-
 </Steps>
 
 </TabsContent>
 
 </Tabs>
-
-<ComponentSource name="example-component" />
 
 ## Props
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,18 @@ Make sure to add any necessary dependencies, tailwind configurations, or other p
 pnpm build:registry
 ```
 
+### 7. Format and fix linting before committing
+
+```bash
+pnpm format:write
+```
+
+```bash
+pnpm lint:fix
+```
+
+Make sure to run these two commands before committing your changes.
+
 ## Adding to the showcase
 
 ### 1. Create your showcase as a MDX file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,9 +144,9 @@ npx shadcn@latest add "https://magicui.design/r/example-component"
 
 ## Props
 
-| Prop  | Type   | Description                | Default |
-| ----- | ------ | -------------------------- | ------- |
-| color | String | The color of the component | "blue"  |
+| Prop    | Type     | Default  | Description                |
+| ------- | -------- | -------- | -------------------------- |
+| `color` | `String` | `"blue"` | The color of the component |
 ````
 
 ### 5. Update Registry


### PR DESCRIPTION
Before 
![image](https://github.com/user-attachments/assets/cca14916-e7ae-4af6-986d-875ed9255a53)

After
![image](https://github.com/user-attachments/assets/0f64f70d-c5ae-4333-9e81-9c25a21d2323)

Another suggestion is to include the `pnpm format:write` and `pnpm lint:fix` commands in the documentation, so that when everyone is making a PR, it is already formatted and linted correctly.