### PR TITLE
feat(components): add inline style prop support to magicui components

### DIFF
--- a/components/copy-button.tsx
+++ b/components/copy-button.tsx
@@ -79,12 +79,14 @@ interface CopyWithClassNamesProps extends DropdownMenuTriggerProps {
   value: string;
   classNames: string;
   className?: string;
+  style? : React.CSSProperties;
 }
 
 export function CopyWithClassNames({
   value,
   classNames,
   className,
+  style,
   ...props
 }: CopyWithClassNamesProps) {
   const [hasCopied, setHasCopied] = React.useState(false);
@@ -110,6 +112,7 @@ export function CopyWithClassNames({
             "relative z-10 size-6 text-zinc-50 hover:bg-zinc-700 hover:text-zinc-50",
             className,
           )}
+          style={style}
         >
           {hasCopied ? (
             <CheckIcon className="size-3" />

--- a/components/gradient-blur.tsx
+++ b/components/gradient-blur.tsx
@@ -74,3 +74,4 @@ const GradientBlur: React.FC<GradientBlurProps> = ({
 };
 
 export default GradientBlur;
+

--- a/components/gradient-blur.tsx
+++ b/components/gradient-blur.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 interface GradientBlurProps {
   numberOfLayers?: number;
   className?: string;
+  style?: React.CSSProperties;
 }
 
 const GradientBlur: React.FC<GradientBlurProps> = ({

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -314,13 +314,14 @@ const components = {
 interface MDXProps {
   code: string;
   className?: string;
+  style?: React.CSSProperties
 }
 
-export function Mdx({ code, className }: MDXProps) {
+export function Mdx({ code, className, style }: MDXProps) {
   const Component = useMDXComponent(code);
 
   return (
-    <article className={cn("mx-auto max-w-[120ch]", className)}>
+    <article className={cn("mx-auto max-w-[120ch]", className)} style={style}>
       <Component components={components} />
     </article>
   );

--- a/content/docs/components/inline-styles.mdx
+++ b/content/docs/components/inline-styles.mdx
@@ -42,5 +42,23 @@ The style prop has been added to the following component interfaces (3 total):
 - ImageProps in blur-image.tsx
 - BlurFadeProps in blur-fade.tsx
 - GradientBlurProps in gradient-blur.tsx
+- CopyWithClassNamesProps in copy-button.tsx
 
-This enhancement ensures consistent style handling across all major components while maintaining type safety.
+## Update - February 1, 2025 - 6:00 PM EST
+
+Enhanced component styling capabilities by implementing MORE style prop support across multiple components:
+
+- Added style prop implementation to:
+  - BlurFade
+  - Copy-button
+  - MDX-components
+  - Flip-Text
+  - Shine-Border
+  - Word-Rotate
+
+Theses implementation properly forwards style props to underlying elements, ensuring consistent and reliable application of dynamic styles. This enhancement maintains full TypeScript type safety through proper interface inheritance.
+
+Note: Components already implementing React.HTMLAttributes<HTMLElement> or similar interfaces inherently support style props and were left unchanged to maintain existing functionality.
+
+These changes improve component flexibility while preserving the library's type-safe architecture.
+These enhancements ensure consistent style handling across all major components while maintaining type safety.

--- a/content/docs/components/inline-styles.mdx
+++ b/content/docs/components/inline-styles.mdx
@@ -1,0 +1,46 @@
+---
+title: CSS Style Tag Addition
+date: 2025-02-01
+description: Adding the style css option to missing components to allow for more dynamic/flexible design.
+author: Itwela Ibomu
+published: true
+---
+
+## Introduction
+
+I love MAgic Ui. While working with MagicUI, I identified an opportunity to enhance the component library's flexibility by implementing inline style support. This addition enables more dynamic styling capabilities across all components.
+
+## Why This Matters
+
+The addition of the `style` prop provides several key benefits:
+- Enables runtime style modifications
+- Supports dynamic value injection
+- Allows for more complex styling patterns that aren't achievable through className alone
+
+## Implementation Example
+
+Here's a practical example demonstrating the value of this enhancement:
+
+```jsx
+<BlurFade className="h-[200px] w-[32%]" delay={1.618} inView
+    style={{
+        backgroundColor: JK_Colors?.purple,
+        boxShadow: `6.18px 6.18px 0px ${JK_Colors?.purple_accent}`
+    }}>
+    <Link href={'/dashboard/applications'} className="h-[200px] w-[32%] rounded-lg">
+    </Link>
+</BlurFade>
+
+In this example, we're using dynamic color values ( JK_Colors?.purple and JK_Colors?.purple_accent ) that 
+may change during runtime. While Tailwind CSS excels at static styling, it cannot handle dynamic values that 
+might be undefined or change after the initial render. The style prop provides a solution by allowing these 
+values to update reactively.
+
+## Technical Implementation
+The style prop has been added to the following component interfaces (3 total):
+
+- ImageProps in blur-image.tsx
+- BlurFadeProps in blur-fade.tsx
+- GradientBlurProps in gradient-blur.tsx
+
+This enhancement ensures consistent style handling across all major components while maintaining type safety.

--- a/registry/default/magicui/animated-gradient-text.tsx
+++ b/registry/default/magicui/animated-gradient-text.tsx
@@ -28,3 +28,4 @@ export function AnimatedGradientText({
     </div>
   );
 }
+

--- a/registry/default/magicui/animated-grid-pattern.tsx
+++ b/registry/default/magicui/animated-grid-pattern.tsx
@@ -152,3 +152,4 @@ export function AnimatedGridPattern({
     </svg>
   );
 }
+

--- a/registry/default/magicui/blur-fade.tsx
+++ b/registry/default/magicui/blur-fade.tsx
@@ -39,6 +39,7 @@ export function BlurFade({
   inView = false,
   inViewMargin = "-50px",
   blur = "6px",
+  style,
 }: BlurFadeProps) {
   const ref = useRef(null);
   const inViewResult = useInView(ref, { once: true, margin: inViewMargin });
@@ -71,6 +72,7 @@ export function BlurFade({
           ease: "easeOut",
         }}
         className={className}
+        style={style}
       >
         {children}
       </motion.div>

--- a/registry/default/magicui/blur-fade.tsx
+++ b/registry/default/magicui/blur-fade.tsx
@@ -25,6 +25,7 @@ interface BlurFadeProps {
   inView?: boolean;
   inViewMargin?: MarginType;
   blur?: string;
+  style?: React.CSSProperties;
 }
 
 export function BlurFade({

--- a/registry/default/magicui/flip-text.tsx
+++ b/registry/default/magicui/flip-text.tsx
@@ -10,6 +10,7 @@ interface FlipTextProps {
   delayMultiple?: number;
   framerProps?: Variants;
   className?: string;
+  style?: React.CSSProperties
 }
 
 export function FlipText({
@@ -21,6 +22,7 @@ export function FlipText({
     visible: { rotateX: 0, opacity: 1 },
   },
   className,
+  style,
 }: FlipTextProps) {
   return (
     <div className="flex justify-center space-x-2">
@@ -34,6 +36,7 @@ export function FlipText({
             variants={framerProps}
             transition={{ duration, delay: i * delayMultiple }}
             className={cn("origin-center drop-shadow-sm", className)}
+            style={style}
           >
             {char}
           </motion.span>
@@ -42,3 +45,4 @@ export function FlipText({
     </div>
   );
 }
+

--- a/registry/default/magicui/globe.tsx
+++ b/registry/default/magicui/globe.tsx
@@ -36,9 +36,11 @@ const GLOBE_CONFIG: COBEOptions = {
 export function Globe({
   className,
   config = GLOBE_CONFIG,
+  style,
 }: {
   className?: string;
   config?: COBEOptions;
+  style?: React.CSSProperties;
 }) {
   let phi = 0;
   let width = 0;
@@ -99,6 +101,7 @@ export function Globe({
         "absolute inset-0 mx-auto aspect-[1/1] w-full max-w-[600px]",
         className,
       )}
+      style={style}
     >
       <canvas
         className={cn(

--- a/registry/default/magicui/shine-border.tsx
+++ b/registry/default/magicui/shine-border.tsx
@@ -11,6 +11,7 @@ interface ShineBorderProps {
   color?: TColorProp;
   className?: string;
   children: React.ReactNode;
+  style?: React.CSSProperties;
 }
 
 /**
@@ -21,6 +22,7 @@ interface ShineBorderProps {
  * @param duration defines the animation duration to be applied on the shining border
  * @param color a string or string array to define border color.
  * @param className defines the class name to be applied to the component
+ * @param style defines the style to be applied to the component through vanilla css.
  * @param children contains react node elements.
  */
 export function ShineBorder({
@@ -30,14 +32,14 @@ export function ShineBorder({
   color = "#000000",
   className,
   children,
+  style,
 }: ShineBorderProps) {
   return (
     <div
-      style={
-        {
-          "--border-radius": `${borderRadius}px`,
-        } as React.CSSProperties
-      }
+      style={{
+        "--border-radius": `${borderRadius}px`,
+        ...style
+      } as React.CSSProperties}
       className={cn(
         "relative min-h-[60px] w-fit min-w-[300px] place-items-center rounded-[--border-radius] bg-white p-3 text-black dark:bg-black dark:text-white",
         className,

--- a/registry/default/magicui/word-rotate.tsx
+++ b/registry/default/magicui/word-rotate.tsx
@@ -10,6 +10,7 @@ interface WordRotateProps {
   duration?: number;
   motionProps?: MotionProps;
   className?: string;
+  style?: React.CSSProperties;
 }
 
 export function WordRotate({
@@ -22,6 +23,7 @@ export function WordRotate({
     transition: { duration: 0.25, ease: "easeOut" },
   },
   className,
+  style,
 }: WordRotateProps) {
   const [index, setIndex] = useState(0);
 
@@ -41,6 +43,7 @@ export function WordRotate({
           key={words[index]}
           className={cn(className)}
           {...motionProps}
+          style={style}
         >
           {words[index]}
         </motion.h1>


### PR DESCRIPTION
## Add Inline Style Support to Select MagicUI Components

### Hello MagicUI Team,

My name is Itwela, and I’m a huge fan of MagicUI—I use it frequently in my projects. While working on a recent project, I encountered a limitation: I needed to apply inline styles to one of your components, but the existing props did not support this.

To address this, I’ve added inline style support to three components that I believe would benefit from this enhancement. You can find more details, including examples and the advantages of this addition, in my `inline-styles.mdx` file located at:

@/app/content/docs/components/inline-styles.mdx

I’m really passionate about MagicUI and would love to work with you guys one day. This PR is my first step toward demonstrating my commitment to the project and team.

Looking forward to your feedback!

**Best regards,**  
Itwela