### PR TITLE
fix: scratch to reveal prop typo

### DIFF
--- a/content/docs/components/scratch-to-reveal.mdx
+++ b/content/docs/components/scratch-to-reveal.mdx
@@ -47,7 +47,7 @@ npx shadcn@latest add "https://magicui.design/r/scratch-to-reveal"
 | `height`               | `number`   | `-`     | Height of the scratch container.                                                              |
 | `minScratchPercentage` | `number`   | `50`    | Minimum percentage of scratched area to be considered as completed (Value between 0 and 100). |
 | `children`             | `node`     | `-`     | The content to display in the marquee.                                                        |
-| `onCompete`            | `function` | `-`     | Callback function called when scratch is completed                                            |
+| `onComplete`           | `function` | `-`     | Callback function called when scratch is completed                                            |
 | `gradientColors`       | `string[]` | `-`     | Gradient colors for the scratch effect.                                                       |
 
 ## Credits


### PR DESCRIPTION
Quite self explanatory, minor bug in the docs.
Missing letter `L` in `onComplete` prop
```
onCompete -> onComplete
```