### PR TITLE
feat(ui): add Pro label to sidebar items in mobile view

### DIFF
--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -102,6 +102,11 @@ export function MobileNav() {
                           {item.label}
                         </span>
                       )}
+                      {item.paid && (
+                        <span className="ml-2 rounded-md bg-[#4ade80] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
+                          Pro
+                        </span>
+                      )}
                     </MobileLink>
                   ) : (
                     <span


### PR DESCRIPTION
## Description  
This PR adds the missing **"Pro"** label to the items in the mobile sidebar, ensuring consistency with the sidebar in the web view.  
Previously, only the web sidebar displayed the **"Pro"** label for paid items, while the mobile sidebar did not.  

## Changes  
- ✅ Added the **"Pro"** label to the mobile sidebar items where applicable.  
- ✅ Ensured styling and visibility match the web sidebar.  

## Why is this needed?  
✔️ Improves consistency between mobile and web UI.  
✔️ Prevents user confusion regarding which items are free vs. paid.  

## Testing  
✔️ Verified that **"Pro"** labels appear correctly in both mobile and web sidebars. 