### PR TITLE
feat(sidebar): align title and labels with justify-between for better spacing

### DIFF
--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -92,21 +92,23 @@ export function MobileNav() {
                       href={item.href}
                       onClick={() => item.event && posthog.capture(item.event)}
                       className={cn(
-                        "text-muted-foreground",
+                        "flex justify-between text-muted-foreground",
                         item.disabled && "cursor-not-allowed opacity-60",
                       )}
                     >
                       {item.title}
-                      {item.label && (
-                        <span className="ml-2 rounded-md bg-[#FFBD7A] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
-                          {item.label}
-                        </span>
-                      )}
-                      {item.paid && (
-                        <span className="ml-2 rounded-md bg-[#4ade80] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
-                          Pro
-                        </span>
-                      )}
+                      <div>
+                        {item.label && (
+                          <span className="ml-2 rounded-md bg-[#FFBD7A] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
+                            {item.label}
+                          </span>
+                        )}
+                        {item.paid && (
+                          <span className="ml-2 rounded-md bg-[#4ade80] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
+                            Pro
+                          </span>
+                        )}
+                      </div>
                     </MobileLink>
                   ) : (
                     <span

--- a/components/sidebar-nav.tsx
+++ b/components/sidebar-nav.tsx
@@ -79,19 +79,19 @@ export function DocsSidebarNavItems({
             )}
             <span className="relative z-10 shrink-0">{item.title}</span>
             <div>
-                {item.label && (
-                  <span className="relative z-10 ml-2 rounded-md bg-[#FFBD7A] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
-                    {item.label}
-                  </span>
-                )}
-                {item.paid && (
-                  <span className="relative z-10 ml-2 rounded-md bg-[#4ade80] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
-                    Pro
-                  </span>
-                )}
-                {item.external && (
-                  <ExternalLinkIcon className="relative z-10 ml-2 size-4" />
-                )}
+              {item.label && (
+                <span className="relative z-10 ml-2 rounded-md bg-[#FFBD7A] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
+                  {item.label}
+                </span>
+              )}
+              {item.paid && (
+                <span className="relative z-10 ml-2 rounded-md bg-[#4ade80] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
+                  Pro
+                </span>
+              )}
+              {item.external && (
+                <ExternalLinkIcon className="relative z-10 ml-2 size-4" />
+              )}
             </div>
           </Link>
         ) : (

--- a/components/sidebar-nav.tsx
+++ b/components/sidebar-nav.tsx
@@ -55,7 +55,7 @@ export function DocsSidebarNavItems({
             href={item.href}
             onClick={() => item.event && posthog.capture(item.event)}
             className={cn(
-              "group relative flex h-8 w-full items-center rounded-lg px-2 font-normal text-foreground underline-offset-2 hover:bg-accent hover:text-accent-foreground",
+              "group relative flex h-8 w-full items-center justify-between rounded-lg px-2 font-normal text-foreground underline-offset-2 hover:bg-accent hover:text-accent-foreground",
               item.disabled && "cursor-not-allowed opacity-60",
               pathname === item.href &&
                 "bg-accent font-medium text-accent-foreground",
@@ -78,19 +78,21 @@ export function DocsSidebarNavItems({
               />
             )}
             <span className="relative z-10 shrink-0">{item.title}</span>
-            {item.label && (
-              <span className="relative z-10 ml-2 rounded-md bg-[#FFBD7A] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
-                {item.label}
-              </span>
-            )}
-            {item.paid && (
-              <span className="relative z-10 ml-2 rounded-md bg-[#4ade80] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
-                Pro
-              </span>
-            )}
-            {item.external && (
-              <ExternalLinkIcon className="relative z-10 ml-2 size-4" />
-            )}
+            <div>
+                {item.label && (
+                  <span className="relative z-10 ml-2 rounded-md bg-[#FFBD7A] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
+                    {item.label}
+                  </span>
+                )}
+                {item.paid && (
+                  <span className="relative z-10 ml-2 rounded-md bg-[#4ade80] px-1.5 py-0.5 text-xs leading-none text-[#000000] no-underline group-hover:no-underline">
+                    Pro
+                  </span>
+                )}
+                {item.external && (
+                  <ExternalLinkIcon className="relative z-10 ml-2 size-4" />
+                )}
+            </div>
           </Link>
         ) : (
           <span


### PR DESCRIPTION
## Description  
This update enhances the alignment of the sidebar title and labels (`New`, `Pro`) by using `justify-between`.  
Previously, all elements were aligned to the left, which could cause uneven spacing.  
This improvement applies to both web and mobile views, ensuring a more balanced layout.

Let me know if you want any modifications! 😊

## Before Alignment  
![image](https://github.com/user-attachments/assets/e4914645-1744-42c8-885d-c695a9ab4fab)


## After Alignment  
![image](https://github.com/user-attachments/assets/30493381-f62d-41df-a51d-f81d28355d09)
