### PR TITLE
fix: all mdx are updated with usage example

### DIFF
--- a/content/docs/components/android.mdx
+++ b/content/docs/components/android.mdx
@@ -55,9 +55,7 @@ import { Android } from "@/components/magicui/android";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <Android />
-</div>
+<Android />
 ```
 
 ## Props

--- a/content/docs/components/android.mdx
+++ b/content/docs/components/android.mdx
@@ -48,6 +48,18 @@ npx shadcn@canary add "https://magicui.design/r/android"
 
 <ComponentPreview name="android-demo-3" />
 
+## Usage
+
+```tsx
+import { Android } from "@/components/magicui/android";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <Android />
+</div>
+```
+
 ## Props
 
 | Prop       | Type     | Default | Description                        |

--- a/content/docs/components/animated-beam.mdx
+++ b/content/docs/components/animated-beam.mdx
@@ -66,9 +66,7 @@ import { AnimatedBeam } from "@/components/magicui/animated-beam.tsx";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <AnimatedBeam />
-</div>
+<AnimatedBeam containerRef={containerRef} fromRef={fromRef} toRef={toRef} />
 ```
 
 ## Props

--- a/content/docs/components/animated-beam.mdx
+++ b/content/docs/components/animated-beam.mdx
@@ -59,6 +59,18 @@ npx shadcn@canary add "https://magicui.design/r/animated-beam"
 
 <ComponentPreview name="animated-beam-multiple-outputs" />
 
+## Usage
+
+```tsx
+import { AnimatedBeam } from "@/components/magicui/animated-beam.tsx";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <AnimatedBeam />
+</div>
+```
+
 ## Props
 
 ### Animated Beam

--- a/content/docs/components/animated-circular-progress-bar.mdx
+++ b/content/docs/components/animated-circular-progress-bar.mdx
@@ -47,9 +47,7 @@ import { AnimatedCircularProgressBar } from "@/components/magicui/animated-circu
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <AnimatedCircularProgressBar value={50} />
-</div>
+<AnimatedCircularProgressBar />
 ```
 
 ## Props

--- a/content/docs/components/animated-circular-progress-bar.mdx
+++ b/content/docs/components/animated-circular-progress-bar.mdx
@@ -40,6 +40,18 @@ npx shadcn@canary add "https://magicui.design/r/animated-circular-progress-bar"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { AnimatedCircularProgressBar } from "@/components/magicui/animated-circular-progress-bar";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <AnimatedCircularProgressBar value={50} />
+</div>
+```
+
 ## Props
 
 | Prop                  | Type     | Default | Description                                   |

--- a/content/docs/components/animated-gradient-text.mdx
+++ b/content/docs/components/animated-gradient-text.mdx
@@ -70,7 +70,7 @@ import { AnimatedGradientText } from "@/components/magicui/animated-gradient-tex
 ```
 
 ```tsx
-<AnimatedGradientText>{children}</AnimatedGradientText>
+<AnimatedGradientText>Animated Gradient Text</AnimatedGradientText>
 ```
 
 ## Props

--- a/content/docs/components/animated-gradient-text.mdx
+++ b/content/docs/components/animated-gradient-text.mdx
@@ -37,14 +37,16 @@ npx shadcn@canary add "https://magicui.design/r/animated-gradient-text"
 
 <Step>Add the required CSS animations</Step>
 
-Add the following animations to your global CSS file inside the `@theme inline` block (e.g., `app/globals.css` or similar):
+Add the following animations to your global CSS file.
 
-```css
---animate-gradient: gradient 8s linear infinite;
+```css title="app/globals.css" {2, 4-8}
+@theme inline {
+  --animate-gradient: gradient 8s linear infinite;
 
-@keyframes gradient {
-  to {
-    background-position: var(--bg-size, 300%) 0;
+  @keyframes gradient {
+    to {
+      background-position: var(--bg-size, 300%) 0;
+    }
   }
 }
 ```
@@ -60,6 +62,16 @@ Add the following animations to your global CSS file inside the `@theme inline` 
 ### Custom Speed
 
 <ComponentPreview name="animated-gradient-text-demo-2" />
+
+### Usage
+
+```tsx
+import { AnimatedGradientText } from "@/components/magicui/animated-gradient-text";
+```
+
+```tsx
+<AnimatedGradientText>{children}</AnimatedGradientText>
+```
 
 ## Props
 

--- a/content/docs/components/animated-grid-pattern.mdx
+++ b/content/docs/components/animated-grid-pattern.mdx
@@ -47,12 +47,7 @@ import { AnimatedGridPattern } from "@/components/magicui/animated-grid-pattern"
 ```
 
 ```tsx
-<AnimatedGridPattern
-  numSquares={30}
-  maxOpacity={0.1}
-  duration={3}
-  repeatDelay={1}
-/>
+<AnimatedGridPattern />
 ```
 
 ## Props

--- a/content/docs/components/animated-grid-pattern.mdx
+++ b/content/docs/components/animated-grid-pattern.mdx
@@ -40,6 +40,21 @@ npx shadcn@canary add "https://magicui.design/r/animated-grid-pattern"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { AnimatedGridPattern } from "@/components/magicui/animated-grid-pattern";
+```
+
+```tsx
+<AnimatedGridPattern
+  numSquares={30}
+  maxOpacity={0.1}
+  duration={3}
+  repeatDelay={1}
+/>
+```
+
 ## Props
 
 ### GridPattern

--- a/content/docs/components/animated-list.mdx
+++ b/content/docs/components/animated-list.mdx
@@ -40,6 +40,18 @@ npx shadcn@canary add "https://magicui.design/r/animated-list"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { AnimatedList } from "@/components/magicui/animated-list";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <AnimatedList></AnimatedList>
+</div>
+```
+
 ## Props
 
 ### Animated List

--- a/content/docs/components/animated-list.mdx
+++ b/content/docs/components/animated-list.mdx
@@ -47,9 +47,11 @@ import { AnimatedList } from "@/components/magicui/animated-list";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <AnimatedList></AnimatedList>
-</div>
+<AnimatedList>
+  <p>Item 1</p>
+  <p>Item 2</p>
+  <p>Item 3</p>
+</AnimatedList>
 ```
 
 ## Props

--- a/content/docs/components/animated-shiny-text.mdx
+++ b/content/docs/components/animated-shiny-text.mdx
@@ -70,7 +70,9 @@ import { AnimatedShinyText } from "@/components/magicui/animated-shiny-text";
 ```
 
 ```tsx
-<AnimatedShinyText>{children}</AnimatedShinyText>
+<AnimatedShinyText>
+  <span>Animated Shiny Text</span>
+</AnimatedShinyText>
 ```
 
 ## Props

--- a/content/docs/components/animated-shiny-text.mdx
+++ b/content/docs/components/animated-shiny-text.mdx
@@ -37,20 +37,22 @@ npx shadcn@canary add "https://magicui.design/r/animated-shiny-text"
 
 <Step>Add the required CSS animations</Step>
 
-Add the following animations to your global CSS file inside the `@theme inline` block (e.g., `app/globals.css` or similar):
+Add the following animations to your global CSS file.
 
-```css
---animate-shiny-text: shiny-text 8s infinite;
+```css title="app/globals.css" {2, 4-14}
+@theme inline {
+  --animate-shiny-text: shiny-text 8s infinite;
 
-@keyframes shiny-text {
-  0%,
-  90%,
-  100% {
-    background-position: calc(-100% - var(--shiny-width)) 0;
-  }
-  30%,
-  60% {
-    background-position: calc(100% + var(--shiny-width)) 0;
+  @keyframes shiny-text {
+    0%,
+    90%,
+    100% {
+      background-position: calc(-100% - var(--shiny-width)) 0;
+    }
+    30%,
+    60% {
+      background-position: calc(100% + var(--shiny-width)) 0;
+    }
   }
 }
 ```
@@ -60,6 +62,16 @@ Add the following animations to your global CSS file inside the `@theme inline` 
 </TabsContent>
 
 </Tabs>
+
+## Usage
+
+```tsx
+import { AnimatedShinyText } from "@/components/magicui/animated-shiny-text";
+```
+
+```tsx
+<AnimatedShinyText>{children}</AnimatedShinyText>
+```
 
 ## Props
 

--- a/content/docs/components/animated-shiny-text.mdx
+++ b/content/docs/components/animated-shiny-text.mdx
@@ -70,9 +70,7 @@ import { AnimatedShinyText } from "@/components/magicui/animated-shiny-text";
 ```
 
 ```tsx
-<AnimatedShinyText>
-  <span>Animated Shiny Text</span>
-</AnimatedShinyText>
+<AnimatedShinyText>Animated Shiny Text</AnimatedShinyText>
 ```
 
 ## Props

--- a/content/docs/components/animated-subscribe-button.mdx
+++ b/content/docs/components/animated-subscribe-button.mdx
@@ -47,8 +47,9 @@ import { AnimatedSubscribeButton } from "@/components/magicui/animated-subscribe
 ```
 
 ```tsx
-<AnimatedSubscribeButton subscribeStatus={false}>
-  {children}
+<AnimatedSubscribeButton>
+  <span>Follow</span>
+  <span>Subscribed</span>
 </AnimatedSubscribeButton>
 ```
 

--- a/content/docs/components/animated-subscribe-button.mdx
+++ b/content/docs/components/animated-subscribe-button.mdx
@@ -40,6 +40,18 @@ npx shadcn@canary add "https://magicui.design/r/animated-subscribe-button"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { AnimatedSubscribeButton } from "@/components/magicui/animated-subscribe-button";
+```
+
+```tsx
+<AnimatedSubscribeButton subscribeStatus={false}>
+  {children}
+</AnimatedSubscribeButton>
+```
+
 ## Props
 
 | Prop              | Type              | Default | Description                                                                                                                                       |

--- a/content/docs/components/aurora-text.mdx
+++ b/content/docs/components/aurora-text.mdx
@@ -36,31 +36,33 @@ npx shadcn@canary add "https://magicui.design/r/aurora-text"
 
 <Step>Add the required CSS animations</Step>
 
-Add the following animations to your global CSS file inside the `@theme inline` block (e.g., `app/globals.css` or similar):
+Add the following animations to your global CSS file.
 
-```css
---animate-aurora: aurora 8s ease-in-out infinite alternate;
+```css title="app/globals.css" {2, 4-25}
+@theme inline {
+  --animate-aurora: aurora 8s ease-in-out infinite alternate;
 
-@keyframes aurora {
-  0% {
-    background-position: 0% 50%;
-    transform: rotate(-5deg) scale(0.9);
-  }
-  25% {
-    background-position: 50% 100%;
-    transform: rotate(5deg) scale(1.1);
-  }
-  50% {
-    background-position: 100% 50%;
-    transform: rotate(-3deg) scale(0.95);
-  }
-  75% {
-    background-position: 50% 0%;
-    transform: rotate(3deg) scale(1.05);
-  }
-  100% {
-    background-position: 0% 50%;
-    transform: rotate(-5deg) scale(0.9);
+  @keyframes aurora {
+    0% {
+      background-position: 0% 50%;
+      transform: rotate(-5deg) scale(0.9);
+    }
+    25% {
+      background-position: 50% 100%;
+      transform: rotate(5deg) scale(1.1);
+    }
+    50% {
+      background-position: 100% 50%;
+      transform: rotate(-3deg) scale(0.95);
+    }
+    75% {
+      background-position: 50% 0%;
+      transform: rotate(3deg) scale(1.05);
+    }
+    100% {
+      background-position: 0% 50%;
+      transform: rotate(-5deg) scale(0.9);
+    }
   }
 }
 ```
@@ -70,6 +72,20 @@ Add the following animations to your global CSS file inside the `@theme inline` 
 </TabsContent>
 
 </Tabs>
+
+## Usage
+
+```tsx
+import { AuroraText } from "@/components/magicui/aurora-text";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <h1 className="text-4xl font-bold tracking-tighter md:text-5xl lg:text-7xl">
+    <AuroraText>{children}</AuroraText>
+  </h1>
+</div>
+```
 
 ## Props
 

--- a/content/docs/components/aurora-text.mdx
+++ b/content/docs/components/aurora-text.mdx
@@ -80,11 +80,9 @@ import { AuroraText } from "@/components/magicui/aurora-text";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <h1 className="text-4xl font-bold tracking-tighter md:text-5xl lg:text-7xl">
-    <AuroraText>{children}</AuroraText>
-  </h1>
-</div>
+<h1 className="text-4xl font-bold tracking-tighter md:text-5xl lg:text-7xl">
+  <AuroraText>Aurora Text</AuroraText>
+</h1>
 ```
 
 ## Props

--- a/content/docs/components/aurora-text.mdx
+++ b/content/docs/components/aurora-text.mdx
@@ -80,9 +80,7 @@ import { AuroraText } from "@/components/magicui/aurora-text";
 ```
 
 ```tsx
-<h1 className="text-4xl font-bold tracking-tighter md:text-5xl lg:text-7xl">
-  <AuroraText>Aurora Text</AuroraText>
-</h1>
+<AuroraText>Aurora Text</AuroraText>
 ```
 
 ## Props

--- a/content/docs/components/avatar-circles.mdx
+++ b/content/docs/components/avatar-circles.mdx
@@ -47,9 +47,7 @@ import { AvatarCircles } from "@/components/magicui/avatar-circles";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <AvatarCircles numPeople={99} avatarUrls={avatars} />
-</div>
+<AvatarCircles numPeople={99} avatarUrls={avatars} />
 ```
 
 ## Props

--- a/content/docs/components/avatar-circles.mdx
+++ b/content/docs/components/avatar-circles.mdx
@@ -40,6 +40,18 @@ npx shadcn@canary add "https://magicui.design/r/avatar-circles"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { AvatarCircles } from "@/components/magicui/avatar-circles";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <AvatarCircles numPeople={99} avatarUrls={avatars} />
+</div>
+```
+
 ## Props
 
 | Prop        | Type     | Default | Description                                   |

--- a/content/docs/components/bento-grid.mdx
+++ b/content/docs/components/bento-grid.mdx
@@ -51,9 +51,7 @@ import { BentoCard, BentoGrid } from "@/components/magicui/bento-grid";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <BentoGrid>
-    <BentoCard />
-  </BentoGrid>
-</div>
+<BentoGrid>
+  <BentoCard />
+</BentoGrid>
 ```

--- a/content/docs/components/bento-grid.mdx
+++ b/content/docs/components/bento-grid.mdx
@@ -43,3 +43,17 @@ npx shadcn@canary add "https://magicui.design/r/bento-grid"
 ## Examples
 
 <ComponentPreview name="bento-demo-vertical" />
+
+## Usage
+
+```tsx
+import { BentoCard, BentoGrid } from "@/components/magicui/bento-grid";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <BentoGrid>
+    <BentoCard />
+  </BentoGrid>
+</div>
+```

--- a/content/docs/components/blur-fade.mdx
+++ b/content/docs/components/blur-fade.mdx
@@ -51,7 +51,11 @@ import { BlurFade } from "@/components/magicui/blur-fade";
 ```
 
 ```tsx
-<BlurFade>{children}</BlurFade>
+<BlurFade>
+  <img src="https://picsum.photos/300/200?random=1" alt="Sample 1" />
+  <img src="https://picsum.photos/300/200?random=2" alt="Sample 2" />
+  <img src="https://picsum.photos/300/200?random=3" alt="Sample 3" />
+</BlurFade>
 ```
 
 ## Props

--- a/content/docs/components/blur-fade.mdx
+++ b/content/docs/components/blur-fade.mdx
@@ -44,6 +44,16 @@ npx shadcn@canary add "https://magicui.design/r/blur-fade"
 
 <ComponentPreview name="blur-fade-text-demo" />
 
+## Usage
+
+```tsx
+import { BlurFade } from "@/components/magicui/blur-fade";
+```
+
+```tsx
+<BlurFade>{children}</BlurFade>
+```
+
 ## Props
 
 | Prop           | Type              | Default   | Description                                                 |

--- a/content/docs/components/border-beam.mdx
+++ b/content/docs/components/border-beam.mdx
@@ -60,7 +60,9 @@ import { BorderBeam } from "@/components/magicui/border-beam.tsx";
 ```
 
 ```tsx
-<BorderBeam />
+<div className="relative h-[500px] w-full overflow-hidden">
+  <BorderBeam />
+</div>
 ```
 
 ## Props

--- a/content/docs/components/border-beam.mdx
+++ b/content/docs/components/border-beam.mdx
@@ -60,9 +60,7 @@ import { BorderBeam } from "@/components/magicui/border-beam.tsx";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <BorderBeam />
-</div>
+<BorderBeam />
 ```
 
 ## Props

--- a/content/docs/components/box-reveal.mdx
+++ b/content/docs/components/box-reveal.mdx
@@ -40,6 +40,16 @@ npx shadcn@canary add "https://magicui.design/r/box-reveal"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { BoxReveal } from "@/components/magicui/box-reveal";
+```
+
+```tsx
+<BoxReveal>{children}</BoxReveal>
+```
+
 ## Props
 
 | Prop        | Type     | Default   | Description                                   |

--- a/content/docs/components/box-reveal.mdx
+++ b/content/docs/components/box-reveal.mdx
@@ -47,9 +47,7 @@ import { BoxReveal } from "@/components/magicui/box-reveal";
 ```
 
 ```tsx
-<BoxReveal>
-  <p>Box Reveal</p>
-</BoxReveal>
+<BoxReveal>Box Reveal</BoxReveal>
 ```
 
 ## Props

--- a/content/docs/components/box-reveal.mdx
+++ b/content/docs/components/box-reveal.mdx
@@ -47,7 +47,9 @@ import { BoxReveal } from "@/components/magicui/box-reveal";
 ```
 
 ```tsx
-<BoxReveal>{children}</BoxReveal>
+<BoxReveal>
+  <p>Box Reveal</p>
+</BoxReveal>
 ```
 
 ## Props

--- a/content/docs/components/code-comparison.mdx
+++ b/content/docs/components/code-comparison.mdx
@@ -38,6 +38,18 @@ npx shadcn@canary add "https://magicui.design/r/code-comparison"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { CodeComparison } from "@/components/magicui/code-comparison";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <CodeComparison beforeCode={beforeCode} afterCode={afterCode} />
+</div>
+```
+
 ## Props
 
 | Prop             | Type     | Default                     | Description                                            |

--- a/content/docs/components/code-comparison.mdx
+++ b/content/docs/components/code-comparison.mdx
@@ -45,9 +45,7 @@ import { CodeComparison } from "@/components/magicui/code-comparison";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <CodeComparison beforeCode={beforeCode} afterCode={afterCode} />
-</div>
+<CodeComparison beforeCode={beforeCode} afterCode={afterCode} />
 ```
 
 ## Props

--- a/content/docs/components/confetti.mdx
+++ b/content/docs/components/confetti.mdx
@@ -76,6 +76,16 @@ npm install canvas-confetti
 
 <ComponentPreview name="confetti-emoji" />
 
+### Usage
+
+```tsx
+import { Confetti } from "@/components/magicui/confetti";
+```
+
+```tsx
+<Confetti />
+```
+
 ## Props
 
 ### Confetti

--- a/content/docs/components/cool-mode.mdx
+++ b/content/docs/components/cool-mode.mdx
@@ -53,9 +53,9 @@ import { CoolMode } from "@/components/magicui/cool-mode";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <CoolMode>{children}</CoolMode>
-</div>
+<CoolMode>
+  <button>Click me</button>
+</CoolMode>
 ```
 
 ## Props

--- a/content/docs/components/cool-mode.mdx
+++ b/content/docs/components/cool-mode.mdx
@@ -46,6 +46,18 @@ npx shadcn@canary add "https://magicui.design/r/cool-mode"
 
 <ComponentPreview name="cool-mode-custom" />
 
+### Usage
+
+```tsx
+import { CoolMode } from "@/components/magicui/cool-mode";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <CoolMode>{children}</CoolMode>
+</div>
+```
+
 ## Props
 
 | Prop            | Type     | Default    | Description                            |

--- a/content/docs/components/dock.mdx
+++ b/content/docs/components/dock.mdx
@@ -58,13 +58,13 @@ import { Dock, DockIcon } from "@/components/magicui/dock";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <Dock>
-    <DockIcon>
-      <Icon name="home" />
-    </DockIcon>
-  </Dock>
-</div>
+<Dock>
+  <DockIcon>
+    <Icon name="home" />
+    <Icon name="settings" />
+    <Icon name="search" />
+  </DockIcon>
+</Dock>
 ```
 
 ## Props

--- a/content/docs/components/dock.mdx
+++ b/content/docs/components/dock.mdx
@@ -55,14 +55,15 @@ npx shadcn@canary add "https://magicui.design/r/dock"
 
 ```tsx
 import { Dock, DockIcon } from "@/components/magicui/dock";
+import { Home, Settings, Search } from "lucide-react";
 ```
 
 ```tsx
 <Dock>
   <DockIcon>
-    <Icon name="home" />
-    <Icon name="settings" />
-    <Icon name="search" />
+    <Home />
+    <Settings />
+    <Search />
   </DockIcon>
 </Dock>
 ```

--- a/content/docs/components/dock.mdx
+++ b/content/docs/components/dock.mdx
@@ -51,6 +51,22 @@ npx shadcn@canary add "https://magicui.design/r/dock"
 
 <ComponentPreview name="dock-demo-3" />
 
+## Usage
+
+```tsx
+import { Dock, DockIcon } from "@/components/magicui/dock";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <Dock>
+    <DockIcon>
+      <Icon name="home" />
+    </DockIcon>
+  </Dock>
+</div>
+```
+
 ## Props
 
 ### Dock

--- a/content/docs/components/dot-pattern.mdx
+++ b/content/docs/components/dot-pattern.mdx
@@ -51,6 +51,18 @@ npx shadcn@canary add "https://magicui.design/r/dot-pattern"
 
 <ComponentPreview name="dot-pattern-with-glow-effect" />
 
+### Usage
+
+```tsx
+import { DotPattern } from "@/components/magicui/dot-pattern";
+```
+
+```tsx
+<div className="relative h-screen w-screen overflow-hidden">
+  <DotPattern />
+</div>
+```
+
 ## Props
 
 ### Dot Pattern

--- a/content/docs/components/dot-pattern.mdx
+++ b/content/docs/components/dot-pattern.mdx
@@ -58,7 +58,7 @@ import { DotPattern } from "@/components/magicui/dot-pattern";
 ```
 
 ```tsx
-<div className="relative h-screen w-screen overflow-hidden">
+<div className="relative h-[500px] w-full overflow-hidden">
   <DotPattern />
 </div>
 ```

--- a/content/docs/components/file-tree.mdx
+++ b/content/docs/components/file-tree.mdx
@@ -47,15 +47,18 @@ import { File, Folder, Tree } from "@/components/magicui/file-tree";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <Tree>
+<Tree>
+  <Folder>
     <Folder>
       <File>
-        <FileIcon />
+        <p>layout.tsx</p>
+      </File>
+      <File>
+        <p>page.tsx</p>
       </File>
     </Folder>
-  </Tree>
-</div>
+  </Folder>
+</Tree>
 ```
 
 ## Props

--- a/content/docs/components/file-tree.mdx
+++ b/content/docs/components/file-tree.mdx
@@ -50,12 +50,8 @@ import { File, Folder, Tree } from "@/components/magicui/file-tree";
 <Tree>
   <Folder>
     <Folder>
-      <File>
-        <p>layout.tsx</p>
-      </File>
-      <File>
-        <p>page.tsx</p>
-      </File>
+      <File>layout.tsx</File>
+      <File>page.tsx</File>
     </Folder>
   </Folder>
 </Tree>

--- a/content/docs/components/file-tree.mdx
+++ b/content/docs/components/file-tree.mdx
@@ -40,6 +40,24 @@ npx shadcn@canary add "https://magicui.design/r/file-tree"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { File, Folder, Tree } from "@/components/magicui/file-tree";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <Tree>
+    <Folder>
+      <File>
+        <FileIcon />
+      </File>
+    </Folder>
+  </Tree>
+</div>
+```
+
 ## Props
 
 ### Tree

--- a/content/docs/components/flickering-grid.mdx
+++ b/content/docs/components/flickering-grid.mdx
@@ -46,6 +46,24 @@ npx shadcn@canary add "https://magicui.design/r/flickering-grid"
 
 <ComponentPreview name="flickering-grid-rounded-demo" />
 
+### Usage
+
+```tsx
+import { FlickeringGrid } from "@/components/magicui/flickering-grid";
+```
+
+```tsx
+<FlickeringGrid
+  squareSize={4}
+  gridGap={6}
+  color="#6B7280"
+  maxOpacity={0.5}
+  flickerChance={0.1}
+  height={800}
+  width={800}
+/>
+```
+
 ## Props
 
 | Prop            | Type     | Default          | Description                           |

--- a/content/docs/components/flickering-grid.mdx
+++ b/content/docs/components/flickering-grid.mdx
@@ -53,15 +53,7 @@ import { FlickeringGrid } from "@/components/magicui/flickering-grid";
 ```
 
 ```tsx
-<FlickeringGrid
-  squareSize={4}
-  gridGap={6}
-  color="#6B7280"
-  maxOpacity={0.5}
-  flickerChance={0.1}
-  height={800}
-  width={800}
-/>
+<FlickeringGrid />
 ```
 
 ## Props

--- a/content/docs/components/flip-text.mdx
+++ b/content/docs/components/flip-text.mdx
@@ -47,7 +47,7 @@ import { FlipText } from "@/components/magicui/flip-text";
 ```
 
 ```tsx
-<FlipText>{children}</FlipText>
+<FlipText>Flip Text</FlipText>
 ```
 
 ## Props

--- a/content/docs/components/flip-text.mdx
+++ b/content/docs/components/flip-text.mdx
@@ -40,6 +40,16 @@ npx shadcn@canary add "https://magicui.design/r/flip-text"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { FlipText } from "@/components/magicui/flip-text";
+```
+
+```tsx
+<FlipText>{children}</FlipText>
+```
+
 ## Props
 
 | Prop            | Type              | Default    | Description                                   |

--- a/content/docs/components/globe.mdx
+++ b/content/docs/components/globe.mdx
@@ -47,6 +47,18 @@ npm install cobe
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { Globe } from "@/components/magicui/globe";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <Globe />
+</div>
+```
+
 ## Props
 
 | Prop        | Type          | Default | Description                                                                                    |

--- a/content/docs/components/globe.mdx
+++ b/content/docs/components/globe.mdx
@@ -54,9 +54,7 @@ import { Globe } from "@/components/magicui/globe";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <Globe />
-</div>
+<Globe />
 ```
 
 ## Props

--- a/content/docs/components/grid-pattern.mdx
+++ b/content/docs/components/grid-pattern.mdx
@@ -58,14 +58,8 @@ import { GridPattern } from "@/components/magicui/grid-pattern";
 ```
 
 ```tsx
-<div className="relative h-screen w-screen overflow-hidden">
-  <GridPattern
-    squares={[
-      [4, 4],
-      [5, 1],
-      [8, 2],
-    ]}
-  />
+<div className="relative h-[500px] w-full overflow-hidden">
+  <GridPattern />
 </div>
 ```
 

--- a/content/docs/components/grid-pattern.mdx
+++ b/content/docs/components/grid-pattern.mdx
@@ -51,6 +51,24 @@ npx shadcn@canary add "https://magicui.design/r/grid-pattern"
 
 <ComponentPreview name="grid-pattern-dashed" />
 
+### Usage
+
+```tsx
+import { GridPattern } from "@/components/magicui/grid-pattern";
+```
+
+```tsx
+<div className="relative h-screen w-screen overflow-hidden">
+  <GridPattern
+    squares={[
+      [4, 4],
+      [5, 1],
+      [8, 2],
+    ]}
+  />
+</div>
+```
+
 ## Props
 
 ### GridPattern

--- a/content/docs/components/hero-video-dialog.mdx
+++ b/content/docs/components/hero-video-dialog.mdx
@@ -46,6 +46,24 @@ npx shadcn@canary add "https://magicui.design/r/hero-video-dialog"
 
 <ComponentPreview name="hero-video-dialog-demo-top-in-bottom-out" />
 
+## Usage
+
+```tsx
+import { HeroVideoDialog } from "@/components/magicui/hero-video-dialog";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <HeroVideoDialog
+    className="block dark:hidden"
+    animationStyle="from-center"
+    videoSrc="https://www.example.com/dummy-video"
+    thumbnailSrc="https://www.example.com/dummy-thumbnail.png"
+    thumbnailAlt="Dummy Video Thumbnail"
+  />
+</div>
+```
+
 ## Props
 
 | Prop             | Type     | Default             | Description                      |

--- a/content/docs/components/hero-video-dialog.mdx
+++ b/content/docs/components/hero-video-dialog.mdx
@@ -53,15 +53,13 @@ import { HeroVideoDialog } from "@/components/magicui/hero-video-dialog";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <HeroVideoDialog
-    className="block dark:hidden"
-    animationStyle="from-center"
-    videoSrc="https://www.example.com/dummy-video"
-    thumbnailSrc="https://www.example.com/dummy-thumbnail.png"
-    thumbnailAlt="Dummy Video Thumbnail"
-  />
-</div>
+<HeroVideoDialog
+  className="block dark:hidden"
+  animationStyle="from-center"
+  videoSrc="https://www.example.com/dummy-video"
+  thumbnailSrc="https://www.example.com/dummy-thumbnail.png"
+  thumbnailAlt="Dummy Video Thumbnail"
+/>
 ```
 
 ## Props

--- a/content/docs/components/hyper-text.mdx
+++ b/content/docs/components/hyper-text.mdx
@@ -53,7 +53,7 @@ import { HyperText } from "@/components/magicui/hyper-text";
 ```
 
 ```tsx
-<HyperText>{children}</HyperText>
+<HyperText>Hover me</HyperText>
 ```
 
 ## Props

--- a/content/docs/components/hyper-text.mdx
+++ b/content/docs/components/hyper-text.mdx
@@ -46,6 +46,16 @@ npm install motion
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { HyperText } from "@/components/magicui/hyper-text";
+```
+
+```tsx
+<HyperText>{children}</HyperText>
+```
+
 ## Props
 
 | Prop             | Type                | Default | Description                                   |

--- a/content/docs/components/icon-cloud.mdx
+++ b/content/docs/components/icon-cloud.mdx
@@ -46,6 +46,18 @@ npx shadcn@canary add "https://magicui.design/r/icon-cloud"
 
 <ComponentPreview name="icon-cloud-demo-3" />
 
+## Usage
+
+```tsx
+import { IconCloud } from "@/components/magicui/icon-cloud";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <IconCloud images={images} />
+</div>
+```
+
 ## Props
 
 | Prop     | Type                | Default | Description                                |

--- a/content/docs/components/interactive-grid-pattern.mdx
+++ b/content/docs/components/interactive-grid-pattern.mdx
@@ -53,7 +53,7 @@ import { InteractiveGridPattern } from "@/components/magicui/interactive-grid-pa
 ```
 
 ```tsx
-<div className="relative h-screen w-screen overflow-hidden">
+<div className="relative h-[500px] w-full overflow-hidden">
   <InteractiveGridPattern />
 </div>
 ```

--- a/content/docs/components/interactive-grid-pattern.mdx
+++ b/content/docs/components/interactive-grid-pattern.mdx
@@ -46,6 +46,18 @@ npx shadcn@canary add "https://magicui.design/r/interactive-grid-pattern"
 
 <ComponentPreview name="interactive-grid-pattern-demo-2" />
 
+### Usage
+
+```tsx
+import { InteractiveGridPattern } from "@/components/magicui/interactive-grid-pattern";
+```
+
+```tsx
+<div className="relative h-screen w-screen overflow-hidden">
+  <InteractiveGridPattern />
+</div>
+```
+
 ## Props
 
 | Prop               | Type               | Description                                                                                   | Default   |

--- a/content/docs/components/interactive-hover-button.mdx
+++ b/content/docs/components/interactive-hover-button.mdx
@@ -47,7 +47,7 @@ import { InteractiveHoverButton } from "@/components/magicui/interactive-hover-b
 ```
 
 ```tsx
-<InteractiveHoverButton>{children}</InteractiveHoverButton>
+<InteractiveHoverButton>Interactive Hover Button</InteractiveHoverButton>
 ```
 
 ## Props

--- a/content/docs/components/interactive-hover-button.mdx
+++ b/content/docs/components/interactive-hover-button.mdx
@@ -40,6 +40,16 @@ npx shadcn@canary add "https://magicui.design/r/interactive-hover-button"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { InteractiveHoverButton } from "@/components/magicui/interactive-hover-button";
+```
+
+```tsx
+<InteractiveHoverButton>{children}</InteractiveHoverButton>
+```
+
 ## Props
 
 | Prop        | Type     | Default  | Description                                   |

--- a/content/docs/components/iphone-15-pro.mdx
+++ b/content/docs/components/iphone-15-pro.mdx
@@ -57,9 +57,7 @@ import { Iphone15Pro } from "@/components/magicui/iphone-15-pro";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <Iphone15Pro />
-</div>
+<Iphone15Pro />
 ```
 
 ## Props

--- a/content/docs/components/iphone-15-pro.mdx
+++ b/content/docs/components/iphone-15-pro.mdx
@@ -50,6 +50,18 @@ npx shadcn@canary add "https://magicui.design/r/iphone-15-pro"
 
 <ComponentPreview name="iphone-15-pro-demo-3" />
 
+## Usage
+
+```tsx
+import { Iphone15Pro } from "@/components/magicui/iphone-15-pro";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <Iphone15Pro />
+</div>
+```
+
 ## Props
 
 | Prop       | Type     | Default | Description                            |

--- a/content/docs/components/lens.mdx
+++ b/content/docs/components/lens.mdx
@@ -50,6 +50,20 @@ npx shadcn@canary add "https://magicui.design/r/lens"
 
 <ComponentPreview name="lens-demo-3" />
 
+## Usage
+
+```tsx
+import { Lens } from "@/components/magicui/lens";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <Lens zoomFactor={2} lensSize={150}>
+    <img src="/images/lens-demo.jpg" alt="Lens Demo" />
+  </Lens>
+</div>
+```
+
 ## Props
 
 | Property          | Type              | Default | Description                                                |

--- a/content/docs/components/lens.mdx
+++ b/content/docs/components/lens.mdx
@@ -57,11 +57,9 @@ import { Lens } from "@/components/magicui/lens";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <Lens zoomFactor={2} lensSize={150}>
-    <img src="/images/lens-demo.jpg" alt="Lens Demo" />
-  </Lens>
-</div>
+<Lens>
+  <img src="/images/lens-demo.jpg" alt="Lens Demo" />
+</Lens>
 ```
 
 ## Props

--- a/content/docs/components/line-shadow-text.mdx
+++ b/content/docs/components/line-shadow-text.mdx
@@ -66,12 +66,7 @@ import { LineShadowText } from "@/components/magicui/line-shadow-text";
 ```
 
 ```tsx
-<h1 className="text-balance text-5xl font-semibold leading-none tracking-tighter sm:text-6xl md:text-7xl lg:text-8xl">
-  Ship
-  <LineShadowText className="italic" shadowColor="red">
-    Fast
-  </LineShadowText>
-</h1>
+<LineShadowText>Magic UI</LineShadowText>
 ```
 
 ## Props

--- a/content/docs/components/line-shadow-text.mdx
+++ b/content/docs/components/line-shadow-text.mdx
@@ -66,7 +66,12 @@ import { LineShadowText } from "@/components/magicui/line-shadow-text";
 ```
 
 ```tsx
-<LineShadowText>{children}</LineShadowText>
+<h1 className="text-balance text-5xl font-semibold leading-none tracking-tighter sm:text-6xl md:text-7xl lg:text-8xl">
+  Ship
+  <LineShadowText className="italic" shadowColor="red">
+    Fast
+  </LineShadowText>
+</h1>
 ```
 
 ## Props

--- a/content/docs/components/line-shadow-text.mdx
+++ b/content/docs/components/line-shadow-text.mdx
@@ -36,17 +36,19 @@ npx shadcn@canary add "https://magicui.design/r/line-shadow-text"
 
 <Step>Add the required CSS animations</Step>
 
-Add the following animations to your global CSS file inside the `@theme inline` block (e.g., `app/globals.css` or similar):
+Add the following animations to your global CSS file.
 
-```css
---animate-line-shadow: line-shadow 15s linear infinite;
+```css title="app/globals.css" {2, 5-12}
+@theme inline {
+  --animate-line-shadow: line-shadow 15s linear infinite;
 
-@keyframes line-shadow {
-  0% {
-    background-position: 0 0;
-  }
-  100% {
-    background-position: 100% -100%;
+  @keyframes line-shadow {
+    0% {
+      background-position: 0 0;
+    }
+    100% {
+      background-position: 100% -100%;
+    }
   }
 }
 ```
@@ -56,6 +58,16 @@ Add the following animations to your global CSS file inside the `@theme inline` 
 </TabsContent>
 
 </Tabs>
+
+## Usage
+
+```tsx
+import { LineShadowText } from "@/components/magicui/line-shadow-text";
+```
+
+```tsx
+<LineShadowText>{children}</LineShadowText>
+```
 
 ## Props
 

--- a/content/docs/components/magic-card.mdx
+++ b/content/docs/components/magic-card.mdx
@@ -47,7 +47,12 @@ import { MagicCard } from "@/registry/magicui/magic-card";
 ```
 
 ```tsx
-<MagicCard>Hello World</MagicCard>
+<MagicCard>
+  <div className="p-4">
+    <p>Hello World</p>
+    <span>Hover me</span>
+  </div>
+</MagicCard>
 ```
 
 ## Props

--- a/content/docs/components/marquee.mdx
+++ b/content/docs/components/marquee.mdx
@@ -85,7 +85,12 @@ import { Marquee } from "@/components/magicui/marquee.tsx";
 
 ```tsx
 <div className="relative overflow-hidden">
-  <Marquee>{children}</Marquee>
+  <Marquee>
+    <span>Next.js</span>
+    <span>React</span>
+    <span>TypeScript</span>
+    <span>Tailwind CSS</span>
+  </Marquee>
 </div>
 ```
 

--- a/content/docs/components/marquee.mdx
+++ b/content/docs/components/marquee.mdx
@@ -84,14 +84,12 @@ import { Marquee } from "@/components/magicui/marquee.tsx";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <Marquee>
-    <span>Next.js</span>
-    <span>React</span>
-    <span>TypeScript</span>
-    <span>Tailwind CSS</span>
-  </Marquee>
-</div>
+<Marquee>
+  <span>Next.js</span>
+  <span>React</span>
+  <span>TypeScript</span>
+  <span>Tailwind CSS</span>
+</Marquee>
 ```
 
 ## Props

--- a/content/docs/components/marquee.mdx
+++ b/content/docs/components/marquee.mdx
@@ -77,6 +77,18 @@ Add the following animations to your global CSS file inside the `@theme inline` 
 
 <ComponentPreview name="marquee-3d" />
 
+## Usage
+
+```tsx
+import { Marquee } from "@/components/magicui/marquee.tsx";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <Marquee>{children}</Marquee>
+</div>
+```
+
 ## Props
 
 | Prop           | Type      | Default | Description                                                                  |

--- a/content/docs/components/meteors.mdx
+++ b/content/docs/components/meteors.mdx
@@ -72,7 +72,9 @@ import { Meteors } from "@/components/magicui/meteors";
 ```
 
 ```tsx
-<Meteors number={20} />
+<div className="relative overflow-hidden h-[300px]">
+  <Meteors />
+</div>
 ```
 
 ## Props

--- a/content/docs/components/meteors.mdx
+++ b/content/docs/components/meteors.mdx
@@ -72,7 +72,7 @@ import { Meteors } from "@/components/magicui/meteors";
 ```
 
 ```tsx
-<div className="relative overflow-hidden h-[300px]">
+<div className="relative overflow-hidden h-[500px] w-full max-w-[350px]">
   <Meteors />
 </div>
 ```

--- a/content/docs/components/meteors.mdx
+++ b/content/docs/components/meteors.mdx
@@ -37,22 +37,24 @@ npx shadcn@canary add "https://magicui.design/r/meteors"
 
 <Step>Add the required CSS animations</Step>
 
-Add the following animations to your global CSS file inside the `@theme inline` block (e.g., `app/globals.css` or similar):
+Add the following animations to your global CSS file.
 
-```css
---animate-meteor: meteor 5s linear infinite;
+```css title="app/globals.css" {2, 4-15}
+@theme inline {
+  --animate-meteor: meteor 5s linear infinite;
 
-@keyframes meteor {
-  0% {
-    transform: rotate(var(--angle)) translateX(0);
-    opacity: 1;
-  }
-  70% {
-    opacity: 1;
-  }
-  100% {
-    transform: rotate(var(--angle)) translateX(-500px);
-    opacity: 0;
+  @keyframes meteor {
+    0% {
+      transform: rotate(var(--angle)) translateX(0);
+      opacity: 1;
+    }
+    70% {
+      opacity: 1;
+    }
+    100% {
+      transform: rotate(var(--angle)) translateX(-500px);
+      opacity: 0;
+    }
   }
 }
 ```
@@ -62,6 +64,16 @@ Add the following animations to your global CSS file inside the `@theme inline` 
 </TabsContent>
 
 </Tabs>
+
+## Usage
+
+```tsx
+import { Meteors } from "@/components/magicui/meteors";
+```
+
+```tsx
+<Meteors number={20} />
+```
 
 ## Props
 

--- a/content/docs/components/morphing-text.mdx
+++ b/content/docs/components/morphing-text.mdx
@@ -38,6 +38,16 @@ npx shadcn@canary add "https://magicui.design/r/morphing-text"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { MorphingText } from "@/components/magicui/morphing-text";
+```
+
+```tsx
+<MorphingText texts={["Hello", "World"]} />
+```
+
 ## Props
 
 | Prop        | Type       | Default | Description                          |

--- a/content/docs/components/neon-gradient-card.mdx
+++ b/content/docs/components/neon-gradient-card.mdx
@@ -36,18 +36,20 @@ npx shadcn@canary add "https://magicui.design/r/neon-gradient-card"
 
 <Step>Add the required CSS animations</Step>
 
-Add the following animations to your global CSS file inside the `@theme inline` block (e.g., `app/globals.css` or similar):
+Add the following animations to your global CSS file .
 
-```css
---animate-background-position-spin: background-position-spin 3000ms infinite
-  alternate;
+```css title="app/globals.css" {2-3, 5-12}
+@theme inline {
+  --animate-background-position-spin: background-position-spin 3000ms infinite
+    alternate;
 
-@keyframes background-position-spin {
-  0% {
-    background-position: top center;
-  }
-  100% {
-    background-position: bottom center;
+  @keyframes background-position-spin {
+    0% {
+      background-position: top center;
+    }
+    100% {
+      background-position: bottom center;
+    }
   }
 }
 ```
@@ -57,6 +59,18 @@ Add the following animations to your global CSS file inside the `@theme inline` 
 </TabsContent>
 
 </Tabs>
+
+## Usage
+
+```tsx
+import { NeonGradientCard } from "@/components/magicui/neon-gradient-card";
+```
+
+```tsx
+<NeonGradientCard>
+  <div>Hello</div>
+</NeonGradientCard>
+```
 
 ## Props
 

--- a/content/docs/components/neon-gradient-card.mdx
+++ b/content/docs/components/neon-gradient-card.mdx
@@ -68,7 +68,10 @@ import { NeonGradientCard } from "@/components/magicui/neon-gradient-card";
 
 ```tsx
 <NeonGradientCard>
-  <div>Hello</div>
+  <div className="p-4">
+    <p>Hello</p>
+    <span>Hover me</span>
+  </div>
 </NeonGradientCard>
 ```
 

--- a/content/docs/components/number-ticker.mdx
+++ b/content/docs/components/number-ticker.mdx
@@ -51,6 +51,16 @@ npx shadcn@canary add "https://magicui.design/r/number-ticker"
 
 <ComponentPreview name="number-ticker-demo-2" />
 
+### Usage
+
+```tsx
+import { NumberTicker } from "@/components/magicui/number-ticker";
+```
+
+```tsx
+<NumberTicker value={100} />
+```
+
 ## Props
 
 | Prop            | Type         | Default | Description                          |

--- a/content/docs/components/orbiting-circles.mdx
+++ b/content/docs/components/orbiting-circles.mdx
@@ -70,8 +70,18 @@ import { OrbitingCircles } from "@/components/magicui/orbiting-circles";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <OrbitingCircles></OrbitingCircles>
+<div className="relative overflow-hidden h-[300px]">
+  <OrbitingCircles>
+    <Icon name="home" />
+    <Icon name="settings" />
+    <Icon name="search" />
+  </OrbitingCircles>
+  <OrbitingCircles>
+    <Icon name="whatsapp" />
+    <Icon name="notion" />
+    <Icon name="openai" />
+    <Icon name="googleDrive" />
+  </OrbitingCircles>
 </div>
 ```
 

--- a/content/docs/components/orbiting-circles.mdx
+++ b/content/docs/components/orbiting-circles.mdx
@@ -37,20 +37,22 @@ npx shadcn@canary add "https://magicui.design/r/orbiting-circles"
 
 <Step>Add the required CSS animations</Step>
 
-Add the following animations to your global CSS file inside the `@theme inline` block (e.g., `app/globals.css` or similar):
+Add the following animations to your global CSS file.
 
-```css
---animate-orbit: orbit calc(var(--duration) * 1s) linear infinite;
+```css title="app/globals.css" {2, 4-14}
+@theme inline {
+  --animate-orbit: orbit calc(var(--duration) * 1s) linear infinite;
 
-@keyframes orbit {
-  0% {
-    transform: rotate(calc(var(--angle) * 1deg))
-      translateY(calc(var(--radius) * 1px)) rotate(calc(var(--angle) * -1deg));
-  }
-  100% {
-    transform: rotate(calc(var(--angle) * 1deg + 360deg))
-      translateY(calc(var(--radius) * 1px))
-      rotate(calc((var(--angle) * -1deg) - 360deg));
+  @keyframes orbit {
+    0% {
+      transform: rotate(calc(var(--angle) * 1deg))
+        translateY(calc(var(--radius) * 1px)) rotate(calc(var(--angle) * -1deg));
+    }
+    100% {
+      transform: rotate(calc(var(--angle) * 1deg + 360deg))
+        translateY(calc(var(--radius) * 1px))
+        rotate(calc((var(--angle) * -1deg) - 360deg));
+    }
   }
 }
 ```
@@ -60,6 +62,18 @@ Add the following animations to your global CSS file inside the `@theme inline` 
 </TabsContent>
 
 </Tabs>
+
+## Usage
+
+```tsx
+import { OrbitingCircles } from "@/components/magicui/orbiting-circles";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <OrbitingCircles></OrbitingCircles>
+</div>
+```
 
 ## Props
 

--- a/content/docs/components/orbiting-circles.mdx
+++ b/content/docs/components/orbiting-circles.mdx
@@ -67,20 +67,21 @@ Add the following animations to your global CSS file.
 
 ```tsx
 import { OrbitingCircles } from "@/components/magicui/orbiting-circles";
+import { File, Settings, Search } from "lucide-react";
 ```
 
 ```tsx
-<div className="relative overflow-hidden h-[300px]">
+<div className="relative overflow-hidden h-[500px] w-full">
   <OrbitingCircles>
-    <Icon name="home" />
-    <Icon name="settings" />
-    <Icon name="search" />
+    <File />
+    <Settings />
+    <File />
   </OrbitingCircles>
-  <OrbitingCircles>
-    <Icon name="whatsapp" />
-    <Icon name="notion" />
-    <Icon name="openai" />
-    <Icon name="googleDrive" />
+  <OrbitingCircles radius={100} reverse>
+    <File />
+    <Settings />
+    <File />
+    <Search />
   </OrbitingCircles>
 </div>
 ```

--- a/content/docs/components/particles.mdx
+++ b/content/docs/components/particles.mdx
@@ -47,7 +47,7 @@ import { Particles } from "@/components/magicui/particles";
 ```
 
 ```tsx
-<div className="relative overflow-hidden h-[300px]">
+<div className="relative overflow-hidden h-[500px] w-full">
   <Particle />
 </div>
 ```

--- a/content/docs/components/particles.mdx
+++ b/content/docs/components/particles.mdx
@@ -47,8 +47,8 @@ import { Particles } from "@/components/magicui/particles";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <Particles quantity={100} ease={60} />
+<div className="relative overflow-hidden h-[300px]">
+  <Particle />
 </div>
 ```
 

--- a/content/docs/components/particles.mdx
+++ b/content/docs/components/particles.mdx
@@ -40,6 +40,18 @@ npx shadcn@canary add "https://magicui.design/r/particles"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { Particles } from "@/components/magicui/particles";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <Particles quantity={100} ease={60} />
+</div>
+```
+
 ## Props
 
 | Prop        | Type      | Default   | Description                      |

--- a/content/docs/components/pulsating-button.mdx
+++ b/content/docs/components/pulsating-button.mdx
@@ -36,18 +36,20 @@ npx shadcn@canary add "https://magicui.design/r/pulsating-button"
 
 <Step>Add the required CSS animations</Step>
 
-Add the following animations to your global CSS file inside the `@theme inline` block (e.g., `app/globals.css` or similar):
+Add the following animations to your global CSS file.
 
-```css
---animate-pulse: pulse var(--duration) ease-out infinite;
+```css title="app/globals.css" {2, 4-12}
+@theme inline {
+  --animate-pulse: pulse var(--duration) ease-out infinite;
 
-@keyframes pulse {
-  0%,
-  100% {
-    box-shadow: 0 0 0 0 var(--pulse-color);
-  }
-  50% {
-    box-shadow: 0 0 0 8px var(--pulse-color);
+  @keyframes pulse {
+    0%,
+    100% {
+      box-shadow: 0 0 0 0 var(--pulse-color);
+    }
+    50% {
+      box-shadow: 0 0 0 8px var(--pulse-color);
+    }
   }
 }
 ```
@@ -57,6 +59,16 @@ Add the following animations to your global CSS file inside the `@theme inline` 
 </TabsContent>
 
 </Tabs>
+
+## Usage
+
+```tsx
+import { PulsatingButton } from "@/components/magicui/pulsating-button";
+```
+
+```tsx
+<PulsatingButton>{children}</PulsatingButton>
+```
 
 ## Props
 

--- a/content/docs/components/pulsating-button.mdx
+++ b/content/docs/components/pulsating-button.mdx
@@ -67,7 +67,7 @@ import { PulsatingButton } from "@/components/magicui/pulsating-button";
 ```
 
 ```tsx
-<PulsatingButton>{children}</PulsatingButton>
+<PulsatingButton>Pulsating Button</PulsatingButton>
 ```
 
 ## Props

--- a/content/docs/components/rainbow-button.mdx
+++ b/content/docs/components/rainbow-button.mdx
@@ -38,7 +38,7 @@ npx shadcn@canary add "https://magicui.design/r/rainbow-button"
 
 Add the following to your `globals.css` file:
 
-```css
+```css title="app/globals.css" {2-6}
 :root {
   --color-1: 0 100% 63%;
   --color-2: 270 100% 63%;
@@ -50,17 +50,19 @@ Add the following to your `globals.css` file:
 
 <Step>Add the required CSS animations</Step>
 
-Add the following animations to your global CSS file inside the `@theme inline` block (e.g., `app/globals.css` or similar):
+Add the following animations to your global CSS file.
 
-```css
---animate-rainbow: rainbow var(--speed, 2s) infinite linear;
+```css title="app/globals.css" {2, 4-11}
+@theme inline {
+  --animate-rainbow: rainbow var(--speed, 2s) infinite linear;
 
-@keyframes rainbow {
-  0% {
-    background-position: 0%;
-  }
-  100% {
-    background-position: 200%;
+  @keyframes rainbow {
+    0% {
+      background-position: 0%;
+    }
+    100% {
+      background-position: 200%;
+    }
   }
 }
 ```
@@ -70,6 +72,16 @@ Add the following animations to your global CSS file inside the `@theme inline` 
 </TabsContent>
 
 </Tabs>
+
+## Usage
+
+```tsx
+import { RainbowButton } from "@/components/magicui/rainbow-button";
+```
+
+```tsx
+<RainbowButton>{children}</RainbowButton>
+```
 
 ## Props
 

--- a/content/docs/components/rainbow-button.mdx
+++ b/content/docs/components/rainbow-button.mdx
@@ -80,7 +80,7 @@ import { RainbowButton } from "@/components/magicui/rainbow-button";
 ```
 
 ```tsx
-<RainbowButton>{children}</RainbowButton>
+<RainbowButton>Rainbow Button</RainbowButton>
 ```
 
 ## Props

--- a/content/docs/components/retro-grid.mdx
+++ b/content/docs/components/retro-grid.mdx
@@ -37,17 +37,19 @@ npx shadcn@canary add "https://magicui.design/r/retro-grid"
 
 <Step>Add the required CSS animations</Step>
 
-Add the following animations to your global CSS file inside the `@theme inline` block (e.g., `app/globals.css` or similar):
+Add the following animations to your global CSS file.
 
-```css
---animate-grid: grid 15s linear infinite;
+```css title="app/globals.css" {2, 4-11}
+@theme inline {
+  --animate-grid: grid 15s linear infinite;
 
-@keyframes grid {
-  0% {
-    transform: translateY(-50%);
-  }
-  100% {
-    transform: translateY(0);
+  @keyframes grid {
+    0% {
+      transform: translateY(-50%);
+    }
+    100% {
+      transform: translateY(0);
+    }
   }
 }
 ```
@@ -57,6 +59,18 @@ Add the following animations to your global CSS file inside the `@theme inline` 
 </TabsContent>
 
 </Tabs>
+
+## Usage
+
+```tsx
+import { RetroGrid } from "@/components/magicui/retro-grid";
+```
+
+```tsx
+<div className="relative h-screen w-screen overflow-hidden">
+  <RetroGrid />
+</div>
+```
 
 ## Props
 

--- a/content/docs/components/retro-grid.mdx
+++ b/content/docs/components/retro-grid.mdx
@@ -67,7 +67,7 @@ import { RetroGrid } from "@/components/magicui/retro-grid";
 ```
 
 ```tsx
-<div className="relative h-screen w-screen overflow-hidden">
+<div className="relative h-[500px] w-full overflow-hidden">
   <RetroGrid />
 </div>
 ```

--- a/content/docs/components/ripple-button.mdx
+++ b/content/docs/components/ripple-button.mdx
@@ -36,18 +36,20 @@ npx shadcn@canary add "https://magicui.design/r/ripple-button"
 
 <Step>Add the required CSS animations</Step>
 
-Add the following animations to your global CSS file inside the `@theme inline` block (e.g., `app/globals.css` or similar):
+Add the following animations to your global CSS file.
 
-```css
---animate-rippling: rippling var(--duration) ease-out;
+```css title="app/globals.css" {2, 4-12}
+@theme inline {
+  --animate-rippling: rippling var(--duration) ease-out;
 
-@keyframes rippling {
-  0% {
-    opacity: 1;
-  }
-  100% {
-    transform: scale(2);
-    opacity: 0;
+  @keyframes rippling {
+    0% {
+      opacity: 1;
+    }
+    100% {
+      transform: scale(2);
+      opacity: 0;
+    }
   }
 }
 ```
@@ -57,6 +59,16 @@ Add the following animations to your global CSS file inside the `@theme inline` 
 </TabsContent>
 
 </Tabs>
+
+## Usage
+
+```tsx
+import { RippleButton } from "@/components/magicui/ripple-button";
+```
+
+```tsx
+<RippleButton rippleColor="#ADD8E6">{children}</RippleButton>
+```
 
 ## Props
 

--- a/content/docs/components/ripple-button.mdx
+++ b/content/docs/components/ripple-button.mdx
@@ -67,7 +67,7 @@ import { RippleButton } from "@/components/magicui/ripple-button";
 ```
 
 ```tsx
-<RippleButton rippleColor="#ADD8E6">{children}</RippleButton>
+<RippleButton>Ripple Button</RippleButton>
 ```
 
 ## Props

--- a/content/docs/components/ripple.mdx
+++ b/content/docs/components/ripple.mdx
@@ -37,19 +37,21 @@ npx shadcn@canary add "https://magicui.design/r/ripple"
 
 <Step>Add the required CSS animations</Step>
 
-Add the following animations to your global CSS file inside the `@theme inline` block (e.g., `app/globals.css` or similar):
+Add the following animations to your global CSS file.
 
-```css
---animate-ripple: ripple var(--duration, 2s) ease calc(var(--i, 0) * 0.2s)
-  infinite;
+```css title="app/globals.css" {2-3, 5-13}
+@theme inline {
+  --animate-ripple: ripple var(--duration, 2s) ease calc(var(--i, 0) * 0.2s)
+    infinite;
 
-@keyframes ripple {
-  0%,
-  100% {
-    transform: translate(-50%, -50%) scale(1);
-  }
-  50% {
-    transform: translate(-50%, -50%) scale(0.9);
+  @keyframes ripple {
+    0%,
+    100% {
+      transform: translate(-50%, -50%) scale(1);
+    }
+    50% {
+      transform: translate(-50%, -50%) scale(0.9);
+    }
   }
 }
 ```
@@ -59,6 +61,18 @@ Add the following animations to your global CSS file inside the `@theme inline` 
 </TabsContent>
 
 </Tabs>
+
+## Usage
+
+```tsx
+import { Ripple } from "@/components/magicui/ripple";
+```
+
+```tsx
+<div className="relative h-screen w-screen overflow-hidden">
+  <Ripple />
+</div>
+```
 
 ## Props
 

--- a/content/docs/components/ripple.mdx
+++ b/content/docs/components/ripple.mdx
@@ -69,7 +69,7 @@ import { Ripple } from "@/components/magicui/ripple";
 ```
 
 ```tsx
-<div className="relative h-screen w-screen overflow-hidden">
+<div className="relative h-[500px] w-full overflow-hidden">
   <Ripple />
 </div>
 ```

--- a/content/docs/components/safari.mdx
+++ b/content/docs/components/safari.mdx
@@ -61,9 +61,7 @@ import { Safari } from "@/components/magicui/safari";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <Safari url="https://magicui.design" />
-</div>
+<Safari url="https://magicui.design" />
 ```
 
 ## Props

--- a/content/docs/components/safari.mdx
+++ b/content/docs/components/safari.mdx
@@ -54,6 +54,18 @@ npx shadcn@canary add "https://magicui.design/r/safari"
 
 <ComponentPreview name="safari-demo-4" />
 
+## Usage
+
+```tsx
+import { Safari } from "@/components/magicui/safari";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <Safari url="https://magicui.design" />
+</div>
+```
+
 ## Props
 
 | Prop       | Type         | Default     | Description                                                 |

--- a/content/docs/components/scratch-to-reveal.mdx
+++ b/content/docs/components/scratch-to-reveal.mdx
@@ -46,7 +46,7 @@ import { ScratchToReveal } from "@/components/magicui/scratch-to-reveal";
 
 ```tsx
 <ScratchToReveal width={300} height={300} minScratchPercentage={50}>
-  <div>Hello</div>
+  <p>Hello</p>
 </ScratchToReveal>
 ```
 

--- a/content/docs/components/scratch-to-reveal.mdx
+++ b/content/docs/components/scratch-to-reveal.mdx
@@ -38,6 +38,18 @@ npx shadcn@canary add "https://magicui.design/r/scratch-to-reveal"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { ScratchToReveal } from "@/components/magicui/scratch-to-reveal";
+```
+
+```tsx
+<ScratchToReveal width={300} height={300} minScratchPercentage={50}>
+  <div>Hello</div>
+</ScratchToReveal>
+```
+
 ## Props
 
 | Prop                   | Type       | Default | Description                                                                                   |

--- a/content/docs/components/scratch-to-reveal.mdx
+++ b/content/docs/components/scratch-to-reveal.mdx
@@ -46,7 +46,7 @@ import { ScratchToReveal } from "@/components/magicui/scratch-to-reveal";
 
 ```tsx
 <ScratchToReveal width={300} height={300} minScratchPercentage={50}>
-  <p>Hello</p>
+  Scratch To Reveal
 </ScratchToReveal>
 ```
 

--- a/content/docs/components/script-copy-btn.mdx
+++ b/content/docs/components/script-copy-btn.mdx
@@ -38,6 +38,18 @@ npx shadcn@canary add "https://magicui.design/r/script-copy-btn"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { ScriptCopyBtn } from "@/components/magicui/script-copy-btn";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <ScriptCopyBtn />
+</div>
+```
+
 ## Props
 
 | Prop                         | Type                     | Default | Description                                                 |

--- a/content/docs/components/script-copy-btn.mdx
+++ b/content/docs/components/script-copy-btn.mdx
@@ -45,9 +45,7 @@ import { ScriptCopyBtn } from "@/components/magicui/script-copy-btn";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <ScriptCopyBtn />
-</div>
+<ScriptCopyBtn />
 ```
 
 ## Props

--- a/content/docs/components/scroll-based-velocity.mdx
+++ b/content/docs/components/scroll-based-velocity.mdx
@@ -53,9 +53,7 @@ import { VelocityScroll } from "@/components/magicui/scroll-based-velocity";
 ```
 
 ```tsx
-<div className="relative w-full overflow-hidden">
-  <VelocityScroll>{children}</VelocityScroll>
-</div>
+<VelocityScroll>Scroll Based Velocity</VelocityScroll>
 ```
 
 ## Props

--- a/content/docs/components/scroll-based-velocity.mdx
+++ b/content/docs/components/scroll-based-velocity.mdx
@@ -46,6 +46,18 @@ npm install motion
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { VelocityScroll } from "@/components/magicui/scroll-based-velocity";
+```
+
+```tsx
+<div className="relative w-full overflow-hidden">
+  <VelocityScroll>{children}</VelocityScroll>
+</div>
+```
+
 ## Props
 
 | Prop              | Type        | Default | Description                                   |

--- a/content/docs/components/scroll-progress.mdx
+++ b/content/docs/components/scroll-progress.mdx
@@ -44,9 +44,7 @@ import { ScrollProgress } from "@/components/magicui/scroll-progress";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <ScrollProgress />
-</div>
+<ScrollProgress />
 ```
 
 ## Props

--- a/content/docs/components/scroll-progress.mdx
+++ b/content/docs/components/scroll-progress.mdx
@@ -37,6 +37,18 @@ npx shadcn@canary add "https://magicui.design/r/scroll-progress"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { ScrollProgress } from "@/components/magicui/scroll-progress";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <ScrollProgress />
+</div>
+```
+
 ## Props
 
 | Prop        | Type     | Default | Description                                   |

--- a/content/docs/components/shimmer-button.mdx
+++ b/content/docs/components/shimmer-button.mdx
@@ -82,9 +82,7 @@ import { ShimmerButton } from "@/components/magicui/shimmer-button";
 ```
 
 ```tsx
-<ShimmerButton>
-  <span>Shimmer Button</span>
-</ShimmerButton>
+<ShimmerButton>Shimmer Button</ShimmerButton>
 ```
 
 ## Props

--- a/content/docs/components/shimmer-button.mdx
+++ b/content/docs/components/shimmer-button.mdx
@@ -37,32 +37,34 @@ npx shadcn@canary add "https://magicui.design/r/shimmer-button"
 
 <Step>Add the required CSS animations</Step>
 
-Add the following animations to your global CSS file inside the `@theme inline` block (e.g., `app/globals.css` or similar):
+Add the following animations to your global CSS file.
 
-```css
---animate-shimmer-slide: shimmer-slide var(--speed) ease-in-out infinite
-  alternate;
---animate-spin-around: spin-around calc(var(--speed) * 2) infinite linear;
+```css title="app/globals.css" {2-4, 6-26}
+@theme inline {
+  --animate-shimmer-slide: shimmer-slide var(--speed) ease-in-out infinite
+    alternate;
+  --animate-spin-around: spin-around calc(var(--speed) * 2) infinite linear;
 
-@keyframes shimmer-slide {
-  to {
-    transform: translate(calc(100cqw - 100%), 0);
+  @keyframes shimmer-slide {
+    to {
+      transform: translate(calc(100cqw - 100%), 0);
+    }
   }
-}
-@keyframes spin-around {
-  0% {
-    transform: translateZ(0) rotate(0);
-  }
-  15%,
-  35% {
-    transform: translateZ(0) rotate(90deg);
-  }
-  65%,
-  85% {
-    transform: translateZ(0) rotate(270deg);
-  }
-  100% {
-    transform: translateZ(0) rotate(360deg);
+  @keyframes spin-around {
+    0% {
+      transform: translateZ(0) rotate(0);
+    }
+    15%,
+    35% {
+      transform: translateZ(0) rotate(90deg);
+    }
+    65%,
+    85% {
+      transform: translateZ(0) rotate(270deg);
+    }
+    100% {
+      transform: translateZ(0) rotate(360deg);
+    }
   }
 }
 ```
@@ -72,6 +74,16 @@ Add the following animations to your global CSS file inside the `@theme inline` 
 </TabsContent>
 
 </Tabs>
+
+## Usage
+
+```tsx
+import { ShimmerButton } from "@/components/magicui/shimmer-button";
+```
+
+```tsx
+<ShimmerButton>{children}</ShimmerButton>
+```
 
 ## Props
 

--- a/content/docs/components/shimmer-button.mdx
+++ b/content/docs/components/shimmer-button.mdx
@@ -82,7 +82,9 @@ import { ShimmerButton } from "@/components/magicui/shimmer-button";
 ```
 
 ```tsx
-<ShimmerButton>{children}</ShimmerButton>
+<ShimmerButton>
+  <span>Shimmer Button</span>
+</ShimmerButton>
 ```
 
 ## Props

--- a/content/docs/components/shine-border.mdx
+++ b/content/docs/components/shine-border.mdx
@@ -36,20 +36,22 @@ npx shadcn@canary add "https://magicui.design/r/shine-border"
 
 <Step>Add the required CSS animations</Step>
 
-Add the following animations to your global CSS file inside the `@theme inline` block (e.g., `app/globals.css` or similar):
+Add the following animations to your global CSS file.
 
-```css
---animate-shine: shine var(--duration) infinite linear;
+```css title="app/globals.css" {2, 4-14}
+@theme inline {
+  --animate-shine: shine var(--duration) infinite linear;
 
-@keyframes shine {
-  0% {
-    background-position: 0% 0%;
-  }
-  50% {
-    background-position: 100% 100%;
-  }
-  to {
-    background-position: 0% 0%;
+  @keyframes shine {
+    0% {
+      background-position: 0% 0%;
+    }
+    50% {
+      background-position: 100% 100%;
+    }
+    to {
+      background-position: 0% 0%;
+    }
   }
 }
 ```

--- a/content/docs/components/shine-border.mdx
+++ b/content/docs/components/shine-border.mdx
@@ -75,7 +75,7 @@ import { ShineBorder } from "@/registry/magicui/shine-border";
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
+<div className="relative h-[500px] w-full overflow-hidden">
   <ShineBorder />
 </div>
 ```

--- a/content/docs/components/shiny-button.mdx
+++ b/content/docs/components/shiny-button.mdx
@@ -40,6 +40,16 @@ npx shadcn@canary add "https://magicui.design/r/shiny-button"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { ShinyButton } from "@/components/magicui/shiny-button";
+```
+
+```tsx
+<ShinyButton>{children}</ShinyButton>
+```
+
 ## Props
 
 | Prop        | Type              | Default | Description                                   |

--- a/content/docs/components/shiny-button.mdx
+++ b/content/docs/components/shiny-button.mdx
@@ -47,7 +47,7 @@ import { ShinyButton } from "@/components/magicui/shiny-button";
 ```
 
 ```tsx
-<ShinyButton>{children}</ShinyButton>
+<ShinyButton>Shiny Button</ShinyButton>
 ```
 
 ## Props

--- a/content/docs/components/sparkles-text.mdx
+++ b/content/docs/components/sparkles-text.mdx
@@ -40,6 +40,16 @@ npx shadcn@canary add "https://magicui.design/r/sparkles-text"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { SparklesText } from "@/components/magicui/sparkles-text";
+```
+
+```tsx
+<SparklesText text="Sparkles Text" />
+```
+
 ## Props
 
 | Prop            | Type     | Default                                 | Description                                        |

--- a/content/docs/components/spinning-text.mdx
+++ b/content/docs/components/spinning-text.mdx
@@ -47,6 +47,16 @@ npx shadcn@canary add "https://magicui.design/r/spinning-text"
 
 <ComponentPreview name="spinning-text-demo-2" />
 
+### Usage
+
+```tsx
+import { SpinningText } from "@/components/magicui/spinning-text";
+```
+
+```tsx
+<SpinningText>{children}</SpinningText>
+```
+
 ## Props
 
 | Prop         | Type                                         | Default | Description                                             |

--- a/content/docs/components/spinning-text.mdx
+++ b/content/docs/components/spinning-text.mdx
@@ -54,7 +54,7 @@ import { SpinningText } from "@/components/magicui/spinning-text";
 ```
 
 ```tsx
-<SpinningText>{children}</SpinningText>
+<SpinningText>learn more • earn more • grow more •</SpinningText>
 ```
 
 ## Props

--- a/content/docs/components/terminal.mdx
+++ b/content/docs/components/terminal.mdx
@@ -49,13 +49,12 @@ import {
 ```
 
 ```tsx
-<div className="relative overflow-hidden">
-  <Terminal>
-    <TypingAnimation>
-      <AnimatedSpan>Hello, world!</AnimatedSpan>
-    </TypingAnimation>
-  </Terminal>
-</div>
+<Terminal>
+  <TypingAnimation>
+    <AnimatedSpan>Hello, world!</AnimatedSpan>
+    <TypingAnimation>MagicUI is awesome!</TypingAnimation>
+  </TypingAnimation>
+</Terminal>
 ```
 
 ## Props

--- a/content/docs/components/terminal.mdx
+++ b/content/docs/components/terminal.mdx
@@ -38,6 +38,26 @@ npx shadcn@canary add "https://magicui.design/r/terminal"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import {
+  AnimatedSpan,
+  Terminal,
+  TypingAnimation,
+} from "@/components/magicui/terminal";
+```
+
+```tsx
+<div className="relative overflow-hidden">
+  <Terminal>
+    <TypingAnimation>
+      <AnimatedSpan>Hello, world!</AnimatedSpan>
+    </TypingAnimation>
+  </Terminal>
+</div>
+```
+
 ## Props
 
 ### Terminal

--- a/content/docs/components/text-animate.mdx
+++ b/content/docs/components/text-animate.mdx
@@ -82,7 +82,7 @@ import { TextAnimate } from "@/components/magicui/text-animate";
 
 ```tsx
 <TextAnimate animation="blurInUp" by="word">
-  {children}
+  Blur in by word
 </TextAnimate>
 ```
 

--- a/content/docs/components/text-animate.mdx
+++ b/content/docs/components/text-animate.mdx
@@ -74,6 +74,18 @@ npx shadcn@canary add "https://magicui.design/r/text-animate"
 
 <ComponentPreview name="text-animate-demo-9" />
 
+## Usage
+
+```tsx
+import { TextAnimate } from "@/components/magicui/text-animate";
+```
+
+```tsx
+<TextAnimate animation="blurInUp" by="word">
+  {children}
+</TextAnimate>
+```
+
 ## Props
 
 | Prop          | Type                                        | Default    | Description                                               |

--- a/content/docs/components/typing-animation.mdx
+++ b/content/docs/components/typing-animation.mdx
@@ -40,6 +40,16 @@ npx shadcn@canary add "https://magicui.design/r/typing-animation"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { TypingAnimation } from "@/components/magicui/typing-animation";
+```
+
+```tsx
+<TypingAnimation>{children}</TypingAnimation>
+```
+
 ## Props
 
 | Prop          | Type                | Default | Description                                   |

--- a/content/docs/components/typing-animation.mdx
+++ b/content/docs/components/typing-animation.mdx
@@ -47,7 +47,7 @@ import { TypingAnimation } from "@/components/magicui/typing-animation";
 ```
 
 ```tsx
-<TypingAnimation>{children}</TypingAnimation>
+<TypingAnimation>Typing Animation</TypingAnimation>
 ```
 
 ## Props

--- a/content/docs/components/warp-background.mdx
+++ b/content/docs/components/warp-background.mdx
@@ -47,7 +47,12 @@ import { WarpBackground } from "@/components/magicui/warp-background";
 ```
 
 ```tsx
-<WarpBackground>{children}</WarpBackground>
+<WarpBackground>
+  <div className="w-80">
+    <p>Warp Background</p>
+    <p>This is a component that creates a warp background effect.</p>
+  </div>
+</WarpBackground>
 ```
 
 ## Props

--- a/content/docs/components/warp-background.mdx
+++ b/content/docs/components/warp-background.mdx
@@ -40,6 +40,16 @@ npx shadcn@canary add "https://magicui.design/r/warp-background"
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { WarpBackground } from "@/components/magicui/warp-background";
+```
+
+```tsx
+<WarpBackground>{children}</WarpBackground>
+```
+
 ## Props
 
 | Prop           | Type              | Default           | Description                                     |

--- a/content/docs/components/word-rotate.mdx
+++ b/content/docs/components/word-rotate.mdx
@@ -46,6 +46,16 @@ npm install motion
 
 </Tabs>
 
+## Usage
+
+```tsx
+import { WordRotate } from "@/components/magicui/word-rotate";
+```
+
+```tsx
+<WordRotate words={["Word", "Rotate"]} />
+```
+
 ## Props
 
 | Prop          | Type              | Default | Description                                   |


### PR DESCRIPTION
All component docs are updated with the correct 👇

- `global.css`  with line-highlighting
 - usage example