### PR TITLE
Add support for emoji and text character particles

### DIFF
--- a/registry/magicui/cool-mode.tsx
+++ b/registry/magicui/cool-mode.tsx
@@ -99,8 +99,12 @@ const applyParticleEffect = (
       circleSVG.setAttribute("height", size.toString());
 
       particle.appendChild(circleSVG);
-    } else {
+    } else if (particleType.startsWith("http") || particleType.startsWith("/")) {
+      // Handle URL-based images
       particle.innerHTML = `<img src="${particleType}" width="${size}" height="${size}" style="border-radius: 50%">`;
+    } else {
+      // Handle emoji or text characters
+      particle.innerHTML = `<div style="font-size: ${size}px; line-height: 1; text-align: center; width: ${size}px; height: ${size}px;">${particleType}</div>`;
     }
 
     particle.style.position = "absolute";


### PR DESCRIPTION
# Add emoji particle support to CoolMode

This PR enhances CoolMode to support emoji characters as particles. Previously, using emojis would cause 404 errors as the component tried to load them as image URLs.

## Changes
- Added logic to detect if particles are URLs vs text/emoji characters
- Renders emojis with appropriate styling when detected
- Maintains backward compatibility with existing image and circle particles

## Example
```jsx
<CoolMode options={{ 
  particle: "⛈️",  // Weather emoji particles!
  size: 30
}}>
  <div>Content here</div>
</CoolMode>
```

This simple change significantly expands the creative possibilities of CoolMode, allowing for thematic particles like weather emojis, stars (⭐), or any Unicode character.