### PR TITLE
Adding motion dependence in the globe component.

### DIFF
--- a/public/r/globe.json
+++ b/public/r/globe.json
@@ -5,7 +5,8 @@
   "title": "Globe",
   "description": "An autorotating, interactive, and highly performant globe made using WebGL.",
   "dependencies": [
-    "cobe"
+    "cobe",
+    "motion"
   ],
   "files": [
     {

--- a/public/registry.json
+++ b/public/registry.json
@@ -390,7 +390,8 @@
       "title": "Globe",
       "description": "An autorotating, interactive, and highly performant globe made using WebGL.",
       "dependencies": [
-        "cobe"
+        "cobe",
+        "motion"
       ],
       "files": [
         {

--- a/registry.json
+++ b/registry.json
@@ -390,7 +390,8 @@
       "title": "Globe",
       "description": "An autorotating, interactive, and highly performant globe made using WebGL.",
       "dependencies": [
-        "cobe"
+        "cobe",
+        "motion"
       ],
       "files": [
         {

--- a/registry/registry-ui.ts
+++ b/registry/registry-ui.ts
@@ -356,7 +356,7 @@ export const ui: Registry["items"] = [
     title: "Globe",
     description:
       "An autorotating, interactive, and highly performant globe made using WebGL.",
-    dependencies: ["cobe"],
+    dependencies: ["cobe", "motion"],
     files: [
       {
         path: "registry/magicui/globe.tsx",


### PR DESCRIPTION
To resolve the `Module not found: Can't resolve 'motion/react'` error in the globe component in Magic UI: <https://magicui.design/docs/components/globe>

![1_K-WCPQXdb-Sxn4QS3Bi__Q-ezgif com-webp-to-png-converter](https://github.com/user-attachments/assets/42de04e4-23e3-47f1-ba21-5346815b254b)


