### PR TITLE
add type definition for strokeDasharray and add repeatDelay to transition

### DIFF
--- a/registry/magicui/animated-grid-pattern.tsx
+++ b/registry/magicui/animated-grid-pattern.tsx
@@ -17,7 +17,7 @@ export interface AnimatedGridPatternProps
   height?: number;
   x?: number;
   y?: number;
-  strokeDasharray?: any;
+  strokeDasharray?: number;
   numSquares?: number;
   maxOpacity?: number;
   duration?: number;
@@ -81,7 +81,7 @@ export function AnimatedGridPattern({
   // Resize observer to update container dimensions
   useEffect(() => {
     const resizeObserver = new ResizeObserver((entries) => {
-      for (let entry of entries) {
+      for (const entry of entries) {
         setDimensions({
           width: entry.contentRect.width,
           height: entry.contentRect.height,
@@ -136,6 +136,7 @@ export function AnimatedGridPattern({
               duration,
               repeat: 1,
               delay: index * 0.1,
+              repeatDelay,
               repeatType: "reverse",
             }}
             onAnimationComplete={() => updateSquarePosition(id)}


### PR DESCRIPTION
### Bug fix
- Bug
- ![Screenshot 2025-05-17 184716](https://github.com/user-attachments/assets/39c40515-e0c9-4395-bf2b-373fcfbc9f86)
- `Bug fix` 
- While using the `animated-grid-pattern` in NextJS 15 , I was facing an issue, there were 2 errors which were preventing me from deploying my build , to fix them 
  - Update `strokeDasharray` type from `any` to `number`.
  - Add `repeatDelay` to `transition` , so that there is no error for `'repeatDelay' is assigned a value but never used`.