### PR TITLE
fix: typing animation displaying emojis

### DIFF
--- a/registry/example/typing-animation-demo.tsx
+++ b/registry/example/typing-animation-demo.tsx
@@ -1,5 +1,5 @@
 import { TypingAnimation } from "@/registry/magicui/typing-animation";
 
 export default function TypingAnimationDemo() {
-  return <TypingAnimation>Typing Animation</TypingAnimation>;
+  return <TypingAnimation>Typing Animation 👋</TypingAnimation>;
 }

--- a/registry/magicui/typing-animation.tsx
+++ b/registry/magicui/typing-animation.tsx
@@ -60,10 +60,11 @@ export function TypingAnimation({
   useEffect(() => {
     if (!started) return;
 
+    const graphemes = Array.from(children);
     let i = 0;
     const typingEffect = setInterval(() => {
-      if (i < children.length) {
-        setDisplayedText(children.substring(0, i + 1));
+      if (i < graphemes.length) {
+        setDisplayedText(graphemes.slice(0, i + 1).join(""));
         i++;
       } else {
         clearInterval(typingEffect);


### PR DESCRIPTION
**Reason:**
The root cause is in the [TypingAnimation.tsx] component, specifically within the useEffect hook responsible for the typing logic. It iterates through the string using children.length and builds the displayed text using children.substring(0, i + 1). These JavaScript string methods operate on UTF-16 code units, not grapheme clusters. Emojis often consist of multiple code units, causing them to be split incorrectly.
 
**Fix:**
Split the input string into an array of grapheme clusters using const graphemes = Array.from(children);.
Iterate based on graphemes.length.
Reconstruct the displayed text using setDisplayedText(graphemes.slice(0, i + 1).join(""));.
This ensures that each "visible character," including emojis, is treated as a single unit.

https://github.com/user-attachments/assets/fa77f7be-1db9-4575-8bcc-3f14569e6d40

https://github.com/user-attachments/assets/a771c57a-1d31-405f-bbe2-4f4a36d05507





 