### PR TITLE
Add isView prop to AnimatedSpan and TypingAnimation for on-view anima…

### DIFF
--- a/registry/magicui/terminal.tsx
+++ b/registry/magicui/terminal.tsx
@@ -8,24 +8,55 @@ interface AnimatedSpanProps extends MotionProps {
   children: React.ReactNode;
   delay?: number;
   className?: string;
+  isView?: boolean; // Prop to control animation trigger on visibility
 }
 
 export const AnimatedSpan = ({
   children,
   delay = 0,
   className,
+  isView = false, // Default: animation waits for visibility
   ...props
-}: AnimatedSpanProps) => (
-  <motion.div
-    initial={{ opacity: 0, y: -5 }}
-    animate={{ opacity: 1, y: 0 }}
-    transition={{ duration: 0.3, delay: delay / 1000 }}
-    className={cn("grid text-sm font-normal tracking-tight", className)}
-    {...props}
-  >
-    {children}
-  </motion.div>
-);
+}: AnimatedSpanProps) => {
+  const [isVisible, setIsVisible] = useState(!isView); // Start with false if isView=false
+  const elementRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isView) {
+      // Use IntersectionObserver to trigger animation when component is visible
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting) {
+            setIsVisible(true);
+            observer.disconnect(); // Disconnect observer after triggering
+          }
+        },
+        { threshold: 0.1 } // Trigger when 10% of the component is visible
+      );
+
+      if (elementRef.current) {
+        observer.observe(elementRef.current);
+      }
+
+      return () => {
+        observer.disconnect();
+      };
+    }
+  }, [isView]);
+
+  return (
+    <motion.div
+      ref={elementRef}
+      initial={{ opacity: 0, y: -5 }}
+      animate={isVisible ? { opacity: 1, y: 0 } : { opacity: 0, y: -5 }}
+      transition={{ duration: 0.3, delay: delay / 1000 }}
+      className={cn("grid text-sm font-normal tracking-tight", className)}
+      {...props}
+    >
+      {children}
+    </motion.div>
+  );
+};
 
 interface TypingAnimationProps extends MotionProps {
   children: string;
@@ -33,6 +64,7 @@ interface TypingAnimationProps extends MotionProps {
   duration?: number;
   delay?: number;
   as?: React.ElementType;
+  isView?: boolean; // Prop to control animation trigger on visibility
 }
 
 export const TypingAnimation = ({
@@ -41,6 +73,7 @@ export const TypingAnimation = ({
   duration = 60,
   delay = 0,
   as: Component = "span",
+  isView = false, // Default: animation waits for visibility
   ...props
 }: TypingAnimationProps) => {
   if (typeof children !== "string") {
@@ -56,15 +89,42 @@ export const TypingAnimation = ({
   const elementRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
-    const startTimeout = setTimeout(() => {
-      setStarted(true);
-    }, delay);
-    return () => clearTimeout(startTimeout);
-  }, [delay]);
+    if (!isView) {
+      // Use IntersectionObserver to start typing animation when component is visible
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting) {
+            // Start animation with specified delay after visibility
+            const startTimeout = setTimeout(() => {
+              setStarted(true);
+            }, delay);
+            observer.disconnect(); // Disconnect observer after triggering
+            return () => clearTimeout(startTimeout);
+          }
+        },
+        { threshold: 0.1 } // Trigger when 10% of the component is visible
+      );
+
+      if (elementRef.current) {
+        observer.observe(elementRef.current);
+      }
+
+      return () => {
+        observer.disconnect();
+      };
+    } else {
+      // Start animation with delay if isView=true
+      const startTimeout = setTimeout(() => {
+        setStarted(true);
+      }, delay);
+      return () => clearTimeout(startTimeout);
+    }
+  }, [delay, isView]);
 
   useEffect(() => {
     if (!started) return;
 
+    // Handle typing animation
     let i = 0;
     const typingEffect = setInterval(() => {
       if (i < children.length) {


### PR DESCRIPTION
…tion trigger

## Description
Added `isView` prop to `AnimatedSpan` and `TypingAnimation` to trigger animations only when the component is visible (using `IntersectionObserver`). This improves UX by preventing animations from running for elements outside the viewport. The `delay` prop is preserved and applied correctly when the component becomes visible.

## How to Test
1. Set `isView={false}` in `AnimatedSpan` and `TypingAnimation` with different `delay` values (e.g., `delay={500}`).
2. Scroll to the terminal and verify animations start only when visible, respecting the `delay`.
3. Set `isView={true}` to confirm original behavior (animations on page load with `delay`).

## Changes
- Added `isView` prop to `AnimatedSpan` and `TypingAnimation`.
- Implemented `IntersectionObserver` for visibility-based animation triggers.
- Ensured `delay` is applied correctly when component becomes visible.