### PR TITLE
feat: enhance terminal animations should start once in view.

### DIFF
--- a/content/docs/components/interactive-grid-pattern.mdx
+++ b/content/docs/components/interactive-grid-pattern.mdx
@@ -65,5 +65,6 @@ import { InteractiveGridPattern } from "@/components/magicui/interactive-grid-pa
 | `width`            | `number`           | `40`      | Width of each square in the grid                                                              |
 | `height`           | `number`           | `40`      | Height of each square in the grid                                                             |
 | `squares`          | `[number, number]` | `[24,24]` | Number of squares in the grid. First number is horizontal squares, second is vertical squares |
+| `radius`           | `number`           | `-`       | Radius of clipping to a circle                                                                |
 | `className`        | `string`           | `-`       | Class name applied to the grid container                                                      |
 | `squaresClassName` | `string`           | `-`       | Class name applied to individual squares in the grid                                          |

--- a/hooks/use-in-view.ts
+++ b/hooks/use-in-view.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef, useState } from "react";
+
+export function useInView<T extends HTMLElement = HTMLElement>(
+  options?: IntersectionObserverInit
+) {
+  const ref = useRef<T | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new window.IntersectionObserver(
+      ([entry]) => setInView(entry.isIntersecting),
+      options
+    );
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [options]);
+
+  return [ref, inView] as const;
+}

--- a/registry/magicui/interactive-grid-pattern.tsx
+++ b/registry/magicui/interactive-grid-pattern.tsx
@@ -11,6 +11,7 @@ import React, { useState } from "react";
  * @param squares - The number of squares in the grid. The first element is the number of horizontal squares, and the second element is the number of vertical squares.
  * @param className - The class name of the grid.
  * @param squaresClassName - The class name of the squares.
+ * @param radius - The radius of the circle to clip the grid to.
  */
 interface InteractiveGridPatternProps extends React.SVGProps<SVGSVGElement> {
   width?: number;
@@ -18,6 +19,7 @@ interface InteractiveGridPatternProps extends React.SVGProps<SVGSVGElement> {
   squares?: [number, number]; // [horizontal, vertical]
   className?: string;
   squaresClassName?: string;
+  radius?: number;
 }
 
 /**
@@ -32,21 +34,38 @@ export function InteractiveGridPattern({
   squares = [24, 24],
   className,
   squaresClassName,
+  radius,
   ...props
 }: InteractiveGridPatternProps) {
   const [horizontal, vertical] = squares;
   const [hoveredSquare, setHoveredSquare] = useState<number | null>(null);
+  const clipPathId = React.useId();
+
+  const svgWidth = width * horizontal;
+  const svgHeight = height * vertical;
 
   return (
     <svg
-      width={width * horizontal}
-      height={height * vertical}
+      width={svgWidth}
+      height={svgHeight}
       className={cn(
         "absolute inset-0 h-full w-full border border-gray-400/30",
         className,
       )}
+      {...(radius ? { clipPath: `url(#${clipPathId})` } : {})}
       {...props}
     >
+      {radius && (
+        <defs>
+          <clipPath id={clipPathId}>
+            <circle
+              cx={svgWidth / 2}
+              cy={svgHeight / 2}
+              r={radius}
+            />
+          </clipPath>
+        </defs>
+      )}
       {Array.from({ length: horizontal * vertical }).map((_, index) => {
         const x = (index % horizontal) * width;
         const y = Math.floor(index / horizontal) * height;

--- a/registry/magicui/terminal.tsx
+++ b/registry/magicui/terminal.tsx
@@ -3,6 +3,7 @@
 import { cn } from "@/lib/utils";
 import { motion, MotionProps } from "motion/react";
 import { useEffect, useRef, useState } from "react";
+import { useInView } from "@/hooks/use-in-view";
 
 interface AnimatedSpanProps extends MotionProps {
   children: React.ReactNode;
@@ -15,17 +16,22 @@ export const AnimatedSpan = ({
   delay = 0,
   className,
   ...props
-}: AnimatedSpanProps) => (
-  <motion.div
-    initial={{ opacity: 0, y: -5 }}
-    animate={{ opacity: 1, y: 0 }}
-    transition={{ duration: 0.3, delay: delay / 1000 }}
-    className={cn("grid text-sm font-normal tracking-tight", className)}
-    {...props}
-  >
-    {children}
-  </motion.div>
-);
+}: AnimatedSpanProps) => {
+  const [ref, inView] = useInView<HTMLDivElement>();
+
+  return (
+    <motion.div
+      ref={ref}
+      initial={{ opacity: 0, y: -5 }}
+      animate={inView ? { opacity: 1, y: 0 } : false}
+      transition={{ duration: 0.3, delay: delay / 1000 }}
+      className={cn("grid text-sm font-normal tracking-tight", className)}
+      {...props}
+    >
+      {children}
+    </motion.div>
+  );
+};
 
 interface TypingAnimationProps extends MotionProps {
   children: string;
@@ -53,14 +59,15 @@ export const TypingAnimation = ({
 
   const [displayedText, setDisplayedText] = useState<string>("");
   const [started, setStarted] = useState(false);
-  const elementRef = useRef<HTMLElement | null>(null);
+  const [ref, inView] = useInView<HTMLElement>();
 
   useEffect(() => {
+    if (!inView) return;
     const startTimeout = setTimeout(() => {
       setStarted(true);
     }, delay);
     return () => clearTimeout(startTimeout);
-  }, [delay]);
+  }, [delay, inView]);
 
   useEffect(() => {
     if (!started) return;
@@ -82,7 +89,7 @@ export const TypingAnimation = ({
 
   return (
     <MotionComponent
-      ref={elementRef}
+      ref={ref}
       className={cn("text-sm font-normal tracking-tight", className)}
       {...props}
     >


### PR DESCRIPTION
This PR addresses the optimization request in #594: animations should only play when elements enter the viewport.

Main changes:
- Added a custom `useInView` hook based on the native Intersection Observer API, with zero extra dependencies for a smaller bundle and better open-source friendliness.
- Integrated `useInView` into the `AnimatedSpan` and `TypingAnimation` components, so animations are triggered only when the elements become visible in the viewport.

This improves both performance and user experience by preventing animations from playing when not visible.

Close #594