### PR TITLE
Add Comic Text component

### DIFF
--- a/__registry__/index.tsx
+++ b/__registry__/index.tsx
@@ -1103,6 +1103,29 @@ export const Index: Record<string, any> = {
     }),
     meta: undefined,
   },
+  "comic-text": {
+    name: "comic-text",
+    description: "Comic text animation",
+    type: "registry:ui",
+    registryDependencies: undefined,
+    files: [
+      {
+        path: "registry/magicui/comic-text.tsx",
+        type: "registry:ui",
+        target: "components/magicui/comic-text.tsx",
+      },
+    ],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/magicui/comic-text.tsx");
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object",
+        ) || item.name;
+      return { default: mod.default || mod[exportName] };
+    }),
+    meta: undefined,
+  },
   "icon-cloud": {
     name: "icon-cloud",
     description: "An interactive 3D tag cloud component",
@@ -3456,6 +3479,29 @@ export const Index: Record<string, any> = {
     ],
     component: React.lazy(async () => {
       const mod = await import("@/registry/example/spinning-text-demo-2.tsx");
+      const exportName =
+        Object.keys(mod).find(
+          (key) =>
+            typeof mod[key] === "function" || typeof mod[key] === "object",
+        ) || item.name;
+      return { default: mod.default || mod[exportName] };
+    }),
+    meta: undefined,
+  },
+  "comic-text-demo": {
+    name: "comic-text-demo",
+    description: "Example showing comic text animation.",
+    type: "registry:example",
+    registryDependencies: ["https://magicui.design/r/comic-text"],
+    files: [
+      {
+        path: "registry/example/comic-text-demo.tsx",
+        type: "registry:example",
+        target: "components/comic-text-demo.tsx",
+      },
+    ],
+    component: React.lazy(async () => {
+      const mod = await import("@/registry/example/comic-text-demo.tsx");
       const exportName =
         Object.keys(mod).find(
           (key) =>

--- a/config/docs.ts
+++ b/config/docs.ts
@@ -472,6 +472,12 @@ export const docsConfig: DocsConfig = {
           items: [],
           label: "",
         },
+        {
+          title: "Comic Text",
+          href: `/docs/components/comic-text`,
+          items: [],
+          label: "New",
+        },
       ],
     },
     {

--- a/content/docs/components/comic-text.mdx
+++ b/content/docs/components/comic-text.mdx
@@ -1,0 +1,65 @@
+---
+title: Comic Text
+date: 2025-07-15
+description: Comic text animation that looks like a comic book text
+author: iambharathpadhu
+published: true
+---
+
+<ComponentPreview name="comic-text-demo" />
+
+## Installation
+
+<Tabs defaultValue="cli">
+
+<TabsList>
+  <TabsTrigger value="cli">CLI</TabsTrigger>
+  <TabsTrigger value="manual">Manual</TabsTrigger>
+</TabsList>
+<TabsContent value="cli">
+
+```bash
+npx shadcn@latest add "https://magicui.design/r/comic-text"
+```
+
+</TabsContent>
+
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Copy and paste the following code into your project.</Step>
+
+<ComponentSource name="comic-text" />
+
+<Step>Update the import paths to match your project setup.</Step>
+
+</Steps>
+
+</TabsContent>
+
+</Tabs>
+
+## Usage
+
+```tsx
+import { ComicText } from "@/components/magicui/comic-text";
+```
+
+```tsx
+<ComicText>Comic Text</ComicText>
+```
+
+## Props
+
+| Prop        | Type            | Default   | Description                                   |
+| ----------- | --------------- | --------- | --------------------------------------------- |
+| `className` | `string`        | `-`       | The class name to be applied to the component |
+| `fontSize`  | `number`        | `4`       | The font size of the text                     |
+| `style`     | `CSSProperties` | `#ffffff` | The style of the text                         |
+| `children`  | `string`        | `-`       | The text to be displayed                      |
+
+
+## Credits
+
+- Credit to [@iambharathpadhu](https://github.com/iambharathpadhu)

--- a/content/docs/components/comic-text.mdx
+++ b/content/docs/components/comic-text.mdx
@@ -59,7 +59,6 @@ import { ComicText } from "@/components/magicui/comic-text";
 | `style`     | `CSSProperties` | `#ffffff` | The style of the text                         |
 | `children`  | `string`        | `-`       | The text to be displayed                      |
 
-
 ## Credits
 
 - Credit to [@iambharathpadhu](https://github.com/iambharathpadhu)

--- a/public/r/comic-text-demo.json
+++ b/public/r/comic-text-demo.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "comic-text-demo",
+  "type": "registry:example",
+  "title": "Comic Text Demo",
+  "description": "Example showing comic text animation.",
+  "registryDependencies": [
+    "https://magicui.design/r/comic-text"
+  ],
+  "files": [
+    {
+      "path": "registry/example/comic-text-demo.tsx",
+      "content": "import { ComicText } from \"@/registry/magicui/comic-text\";\n\nexport default function ComicTextDemo() {\n  return (\n      <div className=\"space-y-8 text-center\">\n        <ComicText fontSize={5}> \n            BOOM!\n        </ComicText>\n      </div>\n  );\n}\n",
+      "type": "registry:example",
+      "target": "components/comic-text-demo.tsx"
+    }
+  ]
+}

--- a/public/r/comic-text.json
+++ b/public/r/comic-text.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "comic-text",
+  "type": "registry:ui",
+  "title": "Comic Text",
+  "description": "Comic text animation",
+  "dependencies": [
+    "motion"
+  ],
+  "files": [
+    {
+      "path": "registry/magicui/comic-text.tsx",
+      "content": "\"use client\";\nimport { cn } from \"@/lib/utils\";\nimport { motion } from \"motion/react\";\nimport { CSSProperties } from \"react\";\n\ntype ComicTextProps = {\n  children: string;\n  className?: string;\n  style?: CSSProperties;\n  fontSize?: number;\n};\n\nexport function ComicText({\n  children,\n  className,\n  style,\n  fontSize = 5,\n}: ComicTextProps) {\n  if (typeof children !== \"string\") {\n    throw new Error(\"children must be a string\");\n  }\n\n  return (\n    <motion.div\n      className={cn(\n        \"select-none text-center\",\n        className\n      )}\n      style={{\n        fontSize: `${fontSize}rem`,\n        fontFamily: \"'Bangers', 'Comic Sans MS', 'Impact', sans-serif\",\n        fontWeight: \"900\",\n        WebkitTextStroke: `${fontSize * 0.35}px #000000`, // Thick black outline\n        transform: \"skewX(-10deg)\",\n        textTransform: \"uppercase\",\n        filter: `\n          drop-shadow(5px 5px 0px #000000) \n          drop-shadow(3px 3px 0px #B71C1C)\n        `,\n        backgroundColor: \"#FDE601\",\n        backgroundImage:\n          \"radial-gradient(circle at 1px 1px, #B71C1C 1px, transparent 0)\",\n        backgroundSize: \"8px 8px\",\n        backgroundClip: \"text\",\n        WebkitBackgroundClip: \"text\",\n        WebkitTextFillColor: \"transparent\",\n        ...style,\n      }}\n      initial={{ opacity: 0, scale: 0.8, rotate: -2 }}\n      animate={{ opacity: 1, scale: 1, rotate: 0 }}\n      transition={{ \n        duration: 0.6, \n        ease: [0.175, 0.885, 0.32, 1.275],\n        type: \"spring\"\n      }}\n    >\n      {children}\n    </motion.div>\n  );\n}\n",
+      "type": "registry:ui",
+      "target": "components/magicui/comic-text.tsx"
+    }
+  ]
+}

--- a/public/registry.json
+++ b/public/registry.json
@@ -906,6 +906,22 @@
       ]
     },
     {
+      "name": "comic-text",
+      "type": "registry:ui",
+      "title": "Comic Text",
+      "description": "Comic text animation",
+      "dependencies": [
+        "motion"
+      ],
+      "files": [
+        {
+          "path": "registry/magicui/comic-text.tsx",
+          "type": "registry:ui",
+          "target": "components/magicui/comic-text.tsx"
+        }
+      ]
+    },
+    {
       "name": "icon-cloud",
       "type": "registry:ui",
       "title": "Icon Cloud",
@@ -2572,6 +2588,22 @@
           "path": "registry/example/spinning-text-demo-2.tsx",
           "type": "registry:example",
           "target": "components/spinning-text-demo-2.tsx"
+        }
+      ]
+    },
+    {
+      "name": "comic-text-demo",
+      "type": "registry:example",
+      "title": "Comic Text Demo",
+      "description": "Example showing comic text animation.",
+      "registryDependencies": [
+        "https://magicui.design/r/comic-text"
+      ],
+      "files": [
+        {
+          "path": "registry/example/comic-text-demo.tsx",
+          "type": "registry:example",
+          "target": "components/comic-text-demo.tsx"
         }
       ]
     },

--- a/registry.json
+++ b/registry.json
@@ -906,6 +906,22 @@
       ]
     },
     {
+      "name": "comic-text",
+      "type": "registry:ui",
+      "title": "Comic Text",
+      "description": "Comic text animation",
+      "dependencies": [
+        "motion"
+      ],
+      "files": [
+        {
+          "path": "registry/magicui/comic-text.tsx",
+          "type": "registry:ui",
+          "target": "components/magicui/comic-text.tsx"
+        }
+      ]
+    },
+    {
       "name": "icon-cloud",
       "type": "registry:ui",
       "title": "Icon Cloud",
@@ -2572,6 +2588,22 @@
           "path": "registry/example/spinning-text-demo-2.tsx",
           "type": "registry:example",
           "target": "components/spinning-text-demo-2.tsx"
+        }
+      ]
+    },
+    {
+      "name": "comic-text-demo",
+      "type": "registry:example",
+      "title": "Comic Text Demo",
+      "description": "Example showing comic text animation.",
+      "registryDependencies": [
+        "https://magicui.design/r/comic-text"
+      ],
+      "files": [
+        {
+          "path": "registry/example/comic-text-demo.tsx",
+          "type": "registry:example",
+          "target": "components/comic-text-demo.tsx"
         }
       ]
     },

--- a/registry/example/comic-text-demo.tsx
+++ b/registry/example/comic-text-demo.tsx
@@ -1,0 +1,9 @@
+import { ComicText } from "@/registry/magicui/comic-text";
+
+export default function ComicTextDemo() {
+  return (
+    <div className="space-y-8 text-center">
+      <ComicText fontSize={5}>BOOM!</ComicText>
+    </div>
+  );
+}

--- a/registry/magicui/comic-text.tsx
+++ b/registry/magicui/comic-text.tsx
@@ -1,0 +1,62 @@
+"use client";
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+import { useTheme } from "next-themes";
+import { CSSProperties } from "react";
+
+type ComicTextProps = {
+  children: string;
+  className?: string;
+  style?: CSSProperties;
+  fontSize?: number;
+};
+
+export function ComicText({
+  children,
+  className,
+  style,
+  fontSize = 5,
+}: ComicTextProps) {
+  const { resolvedTheme } = useTheme();
+
+  if (typeof children !== "string") {
+    throw new Error("children must be a string");
+  }
+
+  const dotColor = "#EF4444";
+  const backgroundColor = "#FACC15";
+
+  return (
+    <motion.div
+      className={cn("select-none text-center", className)}
+      style={{
+        fontSize: `${fontSize}rem`,
+        fontFamily: "'Bangers', 'Comic Sans MS', 'Impact', sans-serif",
+        fontWeight: "900",
+        WebkitTextStroke: `${fontSize * 0.35}px #000000`, // Thick black outline
+        transform: "skewX(-10deg)",
+        textTransform: "uppercase",
+        filter: `
+          drop-shadow(5px 5px 0px #000000) 
+          drop-shadow(3px 3px 0px ${dotColor})
+        `,
+        backgroundColor: backgroundColor,
+        backgroundImage: `radial-gradient(circle at 1px 1px, ${dotColor} 1px, transparent 0)`,
+        backgroundSize: "8px 8px",
+        backgroundClip: "text",
+        WebkitBackgroundClip: "text",
+        WebkitTextFillColor: "transparent",
+        ...style,
+      }}
+      initial={{ opacity: 0, scale: 0.8, rotate: -2 }}
+      animate={{ opacity: 1, scale: 1, rotate: 0 }}
+      transition={{
+        duration: 0.6,
+        ease: [0.175, 0.885, 0.32, 1.275],
+        type: "spring",
+      }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/registry/magicui/comic-text.tsx
+++ b/registry/magicui/comic-text.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { cn } from "@/lib/utils";
 import { motion } from "motion/react";
-import { useTheme } from "next-themes";
 import { CSSProperties } from "react";
 
 type ComicTextProps = {
@@ -17,8 +16,6 @@ export function ComicText({
   style,
   fontSize = 5,
 }: ComicTextProps) {
-  const { resolvedTheme } = useTheme();
-
   if (typeof children !== "string") {
     throw new Error("children must be a string");
   }

--- a/registry/registry-examples.ts
+++ b/registry/registry-examples.ts
@@ -1117,6 +1117,20 @@ export const examples: Registry["items"] = [
     ],
   },
   {
+    name: "comic-text-demo",
+    type: "registry:example",
+    title: "Comic Text Demo",
+    description: "Example showing comic text animation.",
+    registryDependencies: ["https://magicui.design/r/comic-text"],
+    files: [
+      {
+        path: "registry/example/comic-text-demo.tsx",
+        type: "registry:example",
+        target: "components/comic-text-demo.tsx",
+      },
+    ],
+  },
+  {
     name: "icon-cloud-demo",
     type: "registry:example",
     title: "Icon Cloud Demo",

--- a/registry/registry-ui.ts
+++ b/registry/registry-ui.ts
@@ -855,6 +855,20 @@ export const ui: Registry["items"] = [
     ],
   },
   {
+    name: "comic-text",
+    type: "registry:ui",
+    title: "Comic Text",
+    description: "Comic text animation",
+    dependencies: ["motion"],
+    files: [
+      {
+        path: "registry/magicui/comic-text.tsx",
+        type: "registry:ui",
+        target: "components/magicui/comic-text.tsx",
+      },
+    ],
+  },
+  {
     name: "icon-cloud",
     type: "registry:ui",
     title: "Icon Cloud",


### PR DESCRIPTION
This PR introduces a new `Comic Text` component to our Magic UI library. This component renders text with a fun, comic book-style animation, making it perfect for headlines, callouts, or any place you want to add a bit of pop and character.

<img width="1904" height="988" alt="Screenshot 2025-07-15 at 7 28 07 PM" src="https://github.com/user-attachments/assets/0a490d5d-6463-46eb-8352-3865932a0752" />

<img width="1904" height="988" alt="Screenshot 2025-07-15 at 7 28 04 PM" src="https://github.com/user-attachments/assets/f7b84294-8ace-454e-b6a1-eb13aeee1513" />

**Key Features:**

*   **Comic-Inspired Design**: The component styles text to look like it's straight out of a comic book, featuring a thick black outline, a slight skew, and a halftone-dot background effect.
*   **Smooth Animation**: It uses `framer-motion` to add a subtle spring animation on load, making the text appear with a playful bounce.
*   **Customizable**: You can easily change the font size and pass in custom styles and class names.

**What's Included:**

*   The `ComicText` component.
*   A new documentation page (`/docs/components/comic-text`) with installation instructions, usage examples, and prop definitions.
*   A demo of the component on the component page.