### PR TITLE
docs: add section for hiding default browser cursor in SmoothCursor docs

### DIFF
--- a/content/docs/components/smooth-cursor.mdx
+++ b/content/docs/components/smooth-cursor.mdx
@@ -72,6 +72,7 @@ import { SmoothCursor } from "@/components/ui/smooth-cursor";
 ```
 
 ## Hiding Default Browser Cursor
+
 To prevent the default browser cursor from overlapping with the custom cursor, add the following CSS globally:
 
 ```css

--- a/content/docs/components/smooth-cursor.mdx
+++ b/content/docs/components/smooth-cursor.mdx
@@ -71,6 +71,34 @@ import { SmoothCursor } from "@/components/ui/smooth-cursor";
 <SmoothCursor />
 ```
 
+## Hiding Default Browser Cursor
+To prevent the default browser cursor from overlapping with the custom cursor, add the following CSS globally:
+
+```css
+* {
+  cursor: none !important;
+}
+```
+
+### Optional: Keep text cursor for inputs
+
+```css
+input,
+textarea,
+select {
+  cursor: text !important;
+}
+```
+
+💡 If you're using Tailwind CSS, you can add cursor-none to your layout wrapper:
+
+```tsx
+<div className="cursor-none">
+  <SmoothCursor />
+  {/* your app */}
+</div>
+```
+
 ## Props
 
 | Prop           | Type           | Default                | Description                                            |


### PR DESCRIPTION
Added a new section titled "Hiding Default Browser Cursor" to the SmoothCursor documentation. This section explains how to prevent the native browser cursor from overlapping with the custom cursor using global CSS or Tailwind utility classes. Also includes optional handling for form fields like inputs and textareas to preserve usability.