### PR TITLE
fix: update handleMouseEnter to capture mouse coordinates

### DIFF
--- a/registry/magicui/pointer.tsx
+++ b/registry/magicui/pointer.tsx
@@ -45,7 +45,9 @@ export function Pointer({
           y.set(e.clientY);
         };
 
-        const handleMouseEnter = () => {
+        const handleMouseEnter = (e: MouseEvent) => {
+          x.set(e.clientX);
+          y.set(e.clientY);
           setIsActive(true);
         };
 


### PR DESCRIPTION
If the pointer is shown without changing the cursor position after opening the screen, the mouse cursor appears at the top-left corner (x=0, y=0). So I updated the handleMouseEnter function to accept a MouseEvent parameter, allowing it to set the x and y coordinates based on the mouse position when the pointer enters the element.

## Before
https://github.com/user-attachments/assets/2b04e1f2-93ad-4e7c-91ca-a64acba83243

## After

https://github.com/user-attachments/assets/aa79513e-b1f5-4b92-b0b5-080092bbc222
