### PR TITLE
Add isView prop to control annotation animation start

### DIFF
--- a/registry/magicui/highlighter.tsx
+++ b/registry/magicui/highlighter.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { annotate } from "rough-notation";
 import type React from "react";
 
-// Define available annotation actions
 type AnnotationAction =
   | "highlight"
   | "underline"
@@ -14,7 +13,6 @@ type AnnotationAction =
   | "crossed-off"
   | "bracket";
 
-// Custom TypeScript interface for supported props
 interface HighlighterProps {
   children: React.ReactNode;
   action?: AnnotationAction;
@@ -24,43 +22,69 @@ interface HighlighterProps {
   iterations?: number;
   padding?: number;
   multiline?: boolean;
+  isView?: boolean;
 }
 
 export function Highlighter({
   children,
   action = "highlight",
-  color = "#ffd1dc", // Default pink color
+  color = "#ffd1dc",
   strokeWidth = 1.5,
   animationDuration = 600,
   iterations = 2,
   padding = 2,
   multiline = true,
+  isView = false,
 }: HighlighterProps) {
   const elementRef = useRef<HTMLSpanElement>(null);
+  const [isVisible, setIsVisible] = useState(!isView);
 
   useEffect(() => {
+    if (!isView) return;
+
     const element = elementRef.current;
-    if (element) {
-      const annotation = annotate(element, {
-        type: action,
-        color,
-        strokeWidth,
-        animationDuration,
-        iterations,
-        padding,
-        multiline,
-      });
+    if (!element) return;
 
-      annotation.show();
-
-      // Store the current element in closure for cleanup
-      return () => {
-        if (element) {
-          annotate(element, { type: action }).remove();
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
         }
-      };
-    }
+      },
+      { threshold: 0.1 }
+    );
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [isView]);
+
+  useEffect(() => {
+    if (!isVisible) return;
+
+    const element = elementRef.current;
+    if (!element) return;
+
+    const annotation = annotate(element, {
+      type: action,
+      color,
+      strokeWidth,
+      animationDuration,
+      iterations,
+      padding,
+      multiline,
+    });
+
+    annotation.show();
+
+    return () => {
+      if (element) {
+        annotate(element, { type: action }).remove();
+      }
+    };
   }, [
+    isVisible,
     action,
     color,
     strokeWidth,


### PR DESCRIPTION
- By default, animation starts immediately on mount
- When isView is true, animation triggers only when element enters viewport using IntersectionObserver
- Allows better control over animation timing for performance and UX improvements