### PR TITLE
fix(interactive-hover-button): removed repetitive interface

### DIFF
--- a/registry/magicui/interactive-hover-button.tsx
+++ b/registry/magicui/interactive-hover-button.tsx
@@ -2,12 +2,9 @@ import React from "react";
 import { ArrowRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-interface InteractiveHoverButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
-
 export const InteractiveHoverButton = React.forwardRef<
   HTMLButtonElement,
-  InteractiveHoverButtonProps
+  React.ButtonHTMLAttributes<HTMLButtonElement>
 >(({ children, className, ...props }, ref) => {
   return (
     <button


### PR DESCRIPTION
Removed repetitive interface that causes linter error @typescript-eslint/no-empty-interface