### PR TITLE
Fix: 🐛 Magic card's radial gradient not returning after leaving browser on Firefox

### DIFF
--- a/registry/magicui/magic-card.tsx
+++ b/registry/magicui/magic-card.tsx
@@ -32,8 +32,7 @@ export function MagicCard({
     (e: MouseEvent) => {
       if (cardRef.current) {
         const { left, top } = cardRef.current.getBoundingClientRect();
-        const clientX = e.clientX;
-        const clientY = e.clientY;
+        const { clientX, clientY } = e;
         mouseX.set(clientX - left);
         mouseY.set(clientY - top);
       }
@@ -41,34 +40,44 @@ export function MagicCard({
     [mouseX, mouseY],
   );
 
+  // Reset on re-enter so we don't show a stale glow
   const handleMouseOut = useCallback(
-    (e: MouseEvent) => {
-      if (!e.relatedTarget) {
-        document.removeEventListener("mousemove", handleMouseMove);
-        mouseX.set(-gradientSize);
-        mouseY.set(-gradientSize);
-      }
+    () => {
+      mouseX.set(-gradientSize);
+      mouseY.set(-gradientSize);
     },
-    [handleMouseMove, mouseX, gradientSize, mouseY],
+    [gradientSize, mouseX, mouseY],
   );
 
   const handleMouseEnter = useCallback(() => {
-    document.addEventListener("mousemove", handleMouseMove);
     mouseX.set(-gradientSize);
     mouseY.set(-gradientSize);
-  }, [handleMouseMove, mouseX, gradientSize, mouseY]);
+  }, [gradientSize, mouseX, mouseY]);
 
   useEffect(() => {
-    document.addEventListener("mousemove", handleMouseMove);
-    document.addEventListener("mouseout", handleMouseOut);
-    document.addEventListener("mouseenter", handleMouseEnter);
+    // Listeners on window rather than document
+    window.addEventListener("mousemove", handleMouseMove, { passive: true });
+    window.addEventListener("mouseleave", handleMouseOut);
+    window.addEventListener("mouseenter", handleMouseEnter);
+
+    // Also reset when the window/tab is not active
+    const handleWindowBlur = () => handleMouseOut();
+    const handleVisibility = () => {
+      if (document.visibilityState !== "visible") {
+        handleMouseOut();
+      }
+    };
+    window.addEventListener("blur", handleWindowBlur);
+    document.addEventListener("visibilitychange", handleVisibility);
 
     return () => {
-      document.removeEventListener("mousemove", handleMouseMove);
-      document.removeEventListener("mouseout", handleMouseOut);
-      document.removeEventListener("mouseenter", handleMouseEnter);
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseleave", handleMouseOut);
+      window.removeEventListener("mouseenter", handleMouseEnter);
+      window.removeEventListener("blur", handleWindowBlur);
+      document.removeEventListener("visibilitychange", handleVisibility);
     };
-  }, [handleMouseEnter, handleMouseMove, handleMouseOut]);
+  }, [handleMouseMove, handleMouseOut, handleMouseEnter]);
 
   useEffect(() => {
     mouseX.set(-gradientSize);


### PR DESCRIPTION
### **PR Summary**

Hi! Love the component library that has been created with Magic UI. I was implementing the MagicCard component onto one our company's sites and noticed a small bug when testing across browsers. This fork fixes an edge case where the radial gradient would stop rendering after the mouse left the browser window and re-entered. This behavior mostly visible on Firefox.

#### **Issue**

* The shadow is triggered via `group-hover`, but motion values for `mouseX`/`mouseY` were only updated while `document` listeners were active.
* On Firefox, `document.mouseenter` / `document.mouseout` are **not fired** when the cursor exits/enters the browser viewport.
* As a result, once the cursor left the window, the listeners were detached and never reattached, leaving the glow gone until a full page refresh.

#### **Fix**

* Switch from `document`-scoped listeners to `window`-scoped listeners (`mousemove`, `mouseleave`, `mouseenter`) which reliably fire across browsers since it uses the browser viewport rather than the DOM tree to detect mouse movements.
* Add resets on `window.blur` and `document.visibilitychange` so the gradient doesn’t persist when the tab/window is not active.
* Simplify `handleMouseEnter` / `handleMouseOut` to just **reset** the glow's motion value instead of managing dynamic add/remove of listeners.

#### **Changes**

* Replaced `document.addEventListener` calls with `window.addEventListener`.
* Added cleanup for `blur` and `visibilitychange` events.
* Removed dynamic listener toggling logic in favor of always-on listeners + safe resets.

#### **Result**

* Radial gradient now consistently returns when re-entering the browser window in **both Firefox and Chrome**.
* No behavioral regressions; the fix is minimal and scoped to event handling.
