### PR TITLE
fix: neon gradient card text overflow issue

### DIFF
--- a/registry/example/neon-gradient-card-demo.tsx
+++ b/registry/example/neon-gradient-card-demo.tsx
@@ -3,7 +3,7 @@ import { NeonGradientCard } from "@/registry/magicui/neon-gradient-card";
 export default function NeonGradientCardDemo() {
   return (
     <NeonGradientCard className="max-w-sm items-center justify-center text-center">
-      <span className="pointer-events-none z-10 h-full whitespace-pre-wrap bg-gradient-to-br from-[#ff2975] from-35% to-[#00FFF1] bg-clip-text text-center text-6xl font-bold leading-none tracking-tighter text-transparent dark:drop-shadow-[0_5px_5px_rgba(0,0,0,0.8)]">
+      <span className="pointer-events-none z-10 h-full whitespace-pre-wrap bg-gradient-to-br from-[#ff2975] from-35% to-[#00FFF1] bg-clip-text text-center text-3xl md:text-5xl xl:text-6xl font-bold leading-none tracking-tighter text-balance text-transparent dark:drop-shadow-[0_5px_5px_rgba(0,0,0,0.8)]">
         Neon Gradient Card
       </span>
     </NeonGradientCard>

--- a/registry/magicui/neon-gradient-card.tsx
+++ b/registry/magicui/neon-gradient-card.tsx
@@ -140,6 +140,7 @@ export const NeonGradientCard: React.FC<NeonGradientCardProps> = ({
           "after:bg-[linear-gradient(0deg,var(--neon-first-color),var(--neon-second-color))] after:bg-[length:100%_200%] after:opacity-80",
           "after:animate-background-position-spin",
           "dark:bg-neutral-900",
+          "break-words",
         )}
       >
         {children}


### PR DESCRIPTION
This pull request introduces minor improvements to the `NeonGradientCard` component and its demo usage, mainly enhancing text responsiveness and visual presentation.

Styling and Responsiveness Updates:

* Adjusted the text size in the `NeonGradientCardDemo` to be responsive, using `text-3xl` for small screens, `md:text-5xl` for medium screens, and `xl:text-6xl` for large screens, and added `text-balance` for improved text alignment.
* Added the `break-words` utility class to the `NeonGradientCard` component to ensure long text wraps properly within the card.