### PR TITLE
feat(iphone-15-pro): add `webviewSrc` media option and fix aspect ratio

### DIFF
--- a/apps/www/content/docs/components/iphone-15-pro.mdx
+++ b/apps/www/content/docs/components/iphone-15-pro.mdx
@@ -66,7 +66,8 @@ import { Iphone15Pro } from "@/components/magicui/iphone-15-pro";
 | ---------- | -------- | ------- | -------------------------------------- |
 | `width`    | `number` | `433`   | The width of the iPhone 15 Pro window  |
 | `height`   | `number` | `882`   | The height of the iPhone 15 Pro window |
-| `src`      | `string` | `-`     | The source of the image to display     |
+| `imageSrc`      | `string` | `-`     | The source of the image to display     |
 | `videoSrc` | `string` | `-`     | The source of the video to display     |
+| `webviewSrc` | `string` | `-`     | The source of the webview (iframe) to display    |
 
 The `Iphone15Pro` component also accepts all properties of the `SVGElement` type.

--- a/apps/www/content/docs/components/iphone-15-pro.mdx
+++ b/apps/www/content/docs/components/iphone-15-pro.mdx
@@ -62,12 +62,12 @@ import { Iphone15Pro } from "@/components/magicui/iphone-15-pro";
 
 ## Props
 
-| Prop       | Type     | Default | Description                            |
-| ---------- | -------- | ------- | -------------------------------------- |
-| `width`    | `number` | `433`   | The width of the iPhone 15 Pro window  |
-| `height`   | `number` | `882`   | The height of the iPhone 15 Pro window |
-| `imageSrc`      | `string` | `-`     | The source of the image to display     |
-| `videoSrc` | `string` | `-`     | The source of the video to display     |
-| `webviewSrc` | `string` | `-`     | The source of the webview (iframe) to display    |
+| Prop         | Type     | Default | Description                                   |
+| ------------ | -------- | ------- | --------------------------------------------- |
+| `width`      | `number` | `433`   | The width of the iPhone 15 Pro window         |
+| `height`     | `number` | `882`   | The height of the iPhone 15 Pro window        |
+| `imageSrc`   | `string` | `-`     | The source of the image to display            |
+| `videoSrc`   | `string` | `-`     | The source of the video to display            |
+| `webviewSrc` | `string` | `-`     | The source of the webview (iframe) to display |
 
 The `Iphone15Pro` component also accepts all properties of the `SVGElement` type.

--- a/apps/www/registry/example/iphone-15-pro-demo-2.tsx
+++ b/apps/www/registry/example/iphone-15-pro-demo-2.tsx
@@ -5,7 +5,7 @@ export default function Iphone15ProDemo() {
     <div className="relative">
       <Iphone15Pro
         className="size-full"
-        src="https://via.placeholder.com/430x880"
+        imageSrc="https://via.placeholder.com/430x880"
       />
     </div>
   );

--- a/apps/www/registry/example/iphone-15-pro-demo-4.tsx
+++ b/apps/www/registry/example/iphone-15-pro-demo-4.tsx
@@ -1,0 +1,9 @@
+import { Iphone15Pro } from "@/registry/magicui/iphone-15-pro";
+
+export default function Iphone15ProDemo() {
+  return (
+    <div className="relative">
+      <Iphone15Pro className="size-full" webviewSrc="https://magicui.design" />
+    </div>
+  );
+}

--- a/apps/www/registry/magicui/iphone-15-pro.tsx
+++ b/apps/www/registry/magicui/iphone-15-pro.tsx
@@ -5,6 +5,7 @@ export interface Iphone15ProProps extends SVGProps<SVGSVGElement> {
   height?: number;
   imageSrc?: string;
   videoSrc?: string;
+  webviewSrc?: string;
 }
 
 export function Iphone15Pro({
@@ -12,6 +13,7 @@ export function Iphone15Pro({
   height = 882,
   imageSrc,
   videoSrc,
+  webviewSrc,
   ...props
 }: Iphone15ProProps) {
   const originalWidth: number = 433;
@@ -80,6 +82,20 @@ export function Iphone15Pro({
             loop
             muted
             playsInline
+          />
+        </foreignObject>
+      )}
+      {webviewSrc && (
+        <foreignObject x="21.25" y="19.25" width="389.5" height="843.5">
+          <iframe
+            title="iPhone 15 Pro WebView"
+            className="size-full overflow-hidden rounded-[55.75px] object-cover"
+            src={webviewSrc}
+            loading="lazy"
+            allowFullScreen
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+            referrerPolicy="no-referrer"
+            style={{ width: "100%", height: "100%", border: "0" }} // Fallback for browsers that do not support
           />
         </foreignObject>
       )}

--- a/apps/www/registry/magicui/iphone-15-pro.tsx
+++ b/apps/www/registry/magicui/iphone-15-pro.tsx
@@ -3,14 +3,14 @@ import { SVGProps } from "react";
 export interface Iphone15ProProps extends SVGProps<SVGSVGElement> {
   width?: number;
   height?: number;
-  src?: string;
+  imageSrc?: string;
   videoSrc?: string;
 }
 
 export function Iphone15Pro({
   width = 433,
   height = 882,
-  src,
+  imageSrc,
   videoSrc,
   ...props
 }: Iphone15ProProps) {
@@ -60,9 +60,9 @@ export function Iphone15Pro({
         className="fill-[#E5E5E5] stroke-[#E5E5E5] stroke-[0.5] dark:fill-[#404040] dark:stroke-[#404040]"
       />
 
-      {src && (
+      {imageSrc && (
         <image
-          href={src}
+          href={imageSrc}
           x="21.25"
           y="19.25"
           width="389.5"

--- a/apps/www/registry/magicui/iphone-15-pro.tsx
+++ b/apps/www/registry/magicui/iphone-15-pro.tsx
@@ -14,11 +14,14 @@ export function Iphone15Pro({
   videoSrc,
   ...props
 }: Iphone15ProProps) {
+  const originalWidth: number = 433;
+  const originalHeight: number = 882;
+
   return (
     <svg
       width={width}
       height={height}
-      viewBox={`0 0 ${width} ${height}`}
+      viewBox={`0 0 ${originalWidth} ${originalHeight}`} // Maintain original aspect ratio (fixed viewBox)
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       {...props}


### PR DESCRIPTION
## Summary

1. *Fix iPhone 15 Pro sizing* - The current imp doesn't carefully handle the width and height of the iPhone 15 Pro when passed as params, due to an unfixed viewBox. The first commit introduces a fix for this.
2. *Add* `webviewSrc` *and update props* - Introduced a new `webviewSrc` prop to support iframes, and renamed `src` to `imageSrc` prop for clarity 

fix aspect ratio: [demo video](https://www.youtube.com/watch?v=uoFBwFNPkZ4)
`webviewSrc` prop: [demo video](https://www.youtube.com/watch?v=ruWDf9LX274)

## Notes

The current imp doesn't yet cover all edges cases, for example, issues may arise with internal frame src values, safari has more specific rendering quirks, also a fallback should be added when no src is provided (since src opts are all optional params), wrappnig the whole svg in a outer div with adjustments could improve the rendering, especially on iframes.

I decided left these improvements our of this PR to keep the scope focused, but they're on the roadmap.

## Related

- Regarding #780: while I appreciate the contribution, those changes felt too broad. Safari-related issues should be addressed in a more focused way, and that's what i'm planning to tackle next - I've already tackled most of these in a SaaS i'm working on.

btw, @dillionverma — MagicUI is brilliant work! 🎉