### PR TITLE
fix: showcase card links not opening on click

### DIFF
--- a/apps/www/components/sections/showcase.tsx
+++ b/apps/www/components/sections/showcase.tsx
@@ -58,8 +58,7 @@ export function Showcase() {
             .map((showcase, idx) => (
               <ShowcaseCard
                 key={idx}
-                {...showcase}
-                href={showcase.url}
+                href={showcase.data.href ?? showcase.url}
                 title={showcase.data.title ?? ""}
                 affiliation={showcase.data.affiliation ?? ""}
                 image={showcase.data.image ?? ""}

--- a/apps/www/source.config.ts
+++ b/apps/www/source.config.ts
@@ -64,6 +64,7 @@ export const showcase = defineDocs({
       affiliation: z.string().optional(),
       featured: z.boolean().optional().default(false),
       image: z.string().optional(),
+      href: z.string().optional(),
     }),
   },
 })


### PR DESCRIPTION
## Fix showcase card links not opening on click

Fixes #827

### Problem
Clicking on showcase cards wasn't opening the external links - they were using the internal page URL instead.

### Solution
- Added `href` field to showcase schema to support external URLs in frontmatter
- Updated ShowcaseCard to use external `href` with fallback to internal URL

## Before
<img width="987" height="708" alt="before" src="https://github.com/user-attachments/assets/40a5f8ee-9921-4a2a-923b-2a38096a0ae0" />

## After
<img width="962" height="800" alt="after" src="https://github.com/user-attachments/assets/f1f3d455-807f-41c0-9985-238901c1b2a6" />
