### PR TITLE
fix: Pointer show up at init time

### DIFF
--- a/apps/www/registry/magicui/pointer.tsx
+++ b/apps/www/registry/magicui/pointer.tsx
@@ -42,6 +42,7 @@ export function Pointer({
         const handleMouseMove = (e: MouseEvent) => {
           x.set(e.clientX)
           y.set(e.clientY)
+          setIsActive(true)
         }
 
         const handleMouseEnter = (e: MouseEvent) => {


### PR DESCRIPTION
Fix Bug: 
The Custom Poninter is invisible after page refresh, untill move the pointer out of the page and move it back.

- https://github.com/magicuidesign/magicui/issues/852