### PR TITLE
docs: Fix incorrect Dock component example

### DIFF
--- a/apps/www/content/docs/components/dock.mdx
+++ b/apps/www/content/docs/components/dock.mdx
@@ -63,7 +63,11 @@ import { Dock, DockIcon } from "@/components/ui/dock"
 <Dock>
   <DockIcon>
     <Home />
+  </DockIcon>
+  <DockIcon>
     <Settings />
+  </DockIcon>
+  <DockIcon>
     <Search />
   </DockIcon>
 </Dock>


### PR DESCRIPTION
this PR fixes the documentation example for the Dock component. The current example shows multiple icons wrapped inside a single DockIcon component, which creates a break layout where icons are stacked vertically within one dock item. this does not match the demo shown on the website

Changes Made:
- Updated the usage example in `/apps/www/content/docs/components/dock.mdx`
- Changed from single DockIcon containing all icons to multiple DockIcon components

Before:

```
<Dock>
  <DockIcon>
    <Home />
    <Settings />
    <Search />
  </DockIcon>
</Dock>
```

After:

```
<Dock>
  <DockIcon>
    <Home />
  </DockIcon>
  <DockIcon>
    <Settings />
  </DockIcon>
  <DockIcon>
    <Search />
  </DockIcon>
</Dock>
```

issue #870 