### PR TITLE
docs: Fix incorrect Dock component example

### DIFF
--- a/apps/www/content/docs/components/dock.mdx
+++ b/apps/www/content/docs/components/dock.mdx
@@ -63,7 +63,11 @@ import { Dock, DockIcon } from "@/components/ui/dock"
 <Dock>
   <DockIcon>
     <Home />
+  </DockIcon>
+  <DockIcon>
     <Settings />
+  </DockIcon>
+  <DockIcon>
     <Search />
   </DockIcon>
 </Dock>


### PR DESCRIPTION
merging the https://github.com/magicuidesign/magicui/pull/871 about the `dock` usage docs.