### PR TITLE
fix: adjust CopyButton position when title is missing

### DIFF
--- a/apps/www/components/component-source.tsx
+++ b/apps/www/components/component-source.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 
 import { highlightCode } from "@/lib/highlight-code"
 import { getRegistryItem } from "@/lib/registry"
+import { cn } from "@/lib/utils"
 import { CodeCollapsibleWrapper } from "@/components/code-collapsible-wrapper"
 import { CopyButton } from "@/components/copy-button"
 import { getIconForLanguageExtension } from "@/components/icons"
@@ -91,7 +92,7 @@ function ComponentCode({
           {title}
         </figcaption>
       )}
-      <CopyButton value={code} />
+      <CopyButton value={code} className={cn(!title && "top-1.5")} />
       <div
         dangerouslySetInnerHTML={{ __html: highlightedCode }}
         className="h-full"


### PR DESCRIPTION
Fixes #875 

This PR fixes the CopyButton positioning in ComponentSource when a title is not rendered.
The copy button now stays properly aligned for manual installations and other cases where the title is not present.