### PR TITLE
fix(docs): align prev/next navigation with sidebar order

### DIFF
--- a/apps/www/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/apps/www/app/(docs)/docs/[[...slug]]/page.tsx
@@ -8,6 +8,7 @@ import { getBreadcrumbItems } from "fumadocs-core/breadcrumb"
 import { findNeighbour } from "fumadocs-core/server"
 import type { BreadcrumbList, TechArticle, WithContext } from "schema-dts"
 
+import { getNeighboursFromConfig } from "@/config/docs"
 import { siteConfig } from "@/config/site"
 import { replaceComponentSource } from "@/lib/docs"
 import { source } from "@/lib/source"
@@ -89,7 +90,12 @@ export default async function DocPage({ params }: DocPageProps) {
   const { doc, page } = await getDocFromParams({ params })
   const MDX = doc.body
   const content = await doc.getText("raw")
-  const neighbours = findNeighbour(source.pageTree, page.url)
+  const configNeighbours = getNeighboursFromConfig(page.url)
+  const treeNeighbours = findNeighbour(source.pageTree, page.url)
+  const neighbours = {
+    previous: configNeighbours.previous ?? treeNeighbours.previous,
+    next: configNeighbours.next ?? treeNeighbours.next,
+  }
   const breadcrumbs = getBreadcrumbItems(page.url, source.pageTree, {
     includeRoot: { url: "/docs" },
     includePage: true,

--- a/apps/www/config/docs.ts
+++ b/apps/www/config/docs.ts
@@ -5,6 +5,53 @@ interface DocsConfig {
   sidebarNav: NavItemWithChildren[]
 }
 
+export interface DocNavLink {
+  url: string
+  name: string
+}
+
+function flattenSidebarItems(
+  items: NavItemWithChildren[],
+  acc: DocNavLink[] = []
+): DocNavLink[] {
+  for (const item of items) {
+    if (item.href) {
+      acc.push({ url: item.href, name: item.title })
+    }
+    if (item.items?.length) {
+      flattenSidebarItems(item.items, acc)
+    }
+  }
+  return acc
+}
+
+function getFlattenedDocsNav(): DocNavLink[] {
+  const result: DocNavLink[] = []
+  for (const section of docsConfig.sidebarNav) {
+    if (section.items?.length) {
+      flattenSidebarItems(section.items, result)
+    }
+  }
+  return result
+}
+
+export function getNeighboursFromConfig(currentUrl: string): {
+  previous?: DocNavLink
+  next?: DocNavLink
+} {
+  const nav = getFlattenedDocsNav()
+  const normalized = currentUrl.replace(/\/$/, "") || "/"
+  const index = nav.findIndex((item) => {
+    const itemNorm = item.url.replace(/\/$/, "") || "/"
+    return itemNorm === normalized
+  })
+  if (index < 0) return {}
+  return {
+    previous: index > 0 ? nav.at(index - 1) : undefined,
+    next: index < nav.length - 1 ? nav.at(index + 1) : undefined,
+  }
+}
+
 export const docsConfig: DocsConfig = {
   mainNav: [
     {


### PR DESCRIPTION
## Description

This PR fixes the docs **prev/next navigation** so it follows the sidebar order defined in `docsConfig`, instead of the fumadocs page tree (which is alphabetical).

By using the sidebar configuration as the source of truth, this change improves navigation consistency and ensures users move through the docs in the same order they see in the UI.

## Changes

- **Prev/Next source**
  - Prev/next links are now computed from `docsConfig.sidebarNav`, matching the sidebar flow  
    (e.g. Getting Started → Templates → Components by section).

- **`config/docs.ts`**
  - Added `getFlattenedDocsNav()` to flatten `sidebarNav` into a linear list.
  - Added `getNeighboursFromConfig(currentUrl)` to return the previous/next items for a given URL.

- **Doc page logic**
  - `app/(docs)/docs/[[...slug]]/page.tsx` now:
    - Uses `getNeighboursFromConfig(page.url)` first.
    - Falls back to `findNeighbour(source.pageTree, page.url)` when the page is not listed in the config  
      (e.g. new or unlisted docs).

- **URL matching**
  - Normalized trailing slashes so `/docs/installation` and `/docs/installation/` are treated as the same URL.

## Motivation

- **Single source of truth**
  - The sidebar already uses `docsConfig.sidebarNav`, while prev/next relied on fumadocs’ page tree, causing mismatches.

- **Better UX**
  - Users now navigate through the docs in the same order they see in the sidebar  
    (e.g. Components → Special Effects → Animations → …).

- **Easier maintenance**
  - Reordering or adding docs only requires changes in `config/docs.ts`; prev/next updates automatically.

## Breaking Changes

- None for readers of the docs.
- If any code relied on the previous **alphabetical prev/next order** from the fumadocs page tree, that order is no longer used when the page is listed in `docsConfig`.

## Screenshots

N/A — navigation/UX fix with no visual layout changes.