### PR TITLE
fix(docs): align usage imports to components/ui paths

### DIFF
--- a/apps/www/content/docs/components/magic-card.mdx
+++ b/apps/www/content/docs/components/magic-card.mdx
@@ -43,7 +43,7 @@ npx shadcn@latest add @magicui/magic-card
 ## Usage
 
 ```tsx showLineNumbers
-import { MagicCard } from "@/registry/magicui/magic-card"
+import { MagicCard } from "@/components/ui/magic-card"
 ```
 
 ```tsx showLineNumbers

--- a/apps/www/content/docs/components/pixel-image.mdx
+++ b/apps/www/content/docs/components/pixel-image.mdx
@@ -51,7 +51,7 @@ npx shadcn@latest add @magicui/pixel-image
 ## Usage
 
 ```tsx showLineNumbers
-import { PixelImage } from "@/registry/magicui/pixel-image"
+import { PixelImage } from "@/components/ui/pixel-image"
 ```
 
 ```tsx showLineNumbers

--- a/apps/www/content/docs/components/shine-border.mdx
+++ b/apps/www/content/docs/components/shine-border.mdx
@@ -71,7 +71,7 @@ Add the following animations to your global CSS file.
 ## Usage
 
 ```tsx showLineNumbers
-import { ShineBorder } from "@/registry/magicui/shine-border"
+import { ShineBorder } from "@/components/ui/shine-border"
 ```
 
 ```tsx showLineNumbers

--- a/apps/www/content/docs/components/video-text.mdx
+++ b/apps/www/content/docs/components/video-text.mdx
@@ -41,7 +41,7 @@ npx shadcn@latest add @magicui/video-text
 ## Usage
 
 ```tsx showLineNumbers
-import { VideoText } from "@/registry/magicui/video-text"
+import { VideoText } from "@/components/ui/video-text"
 ```
 
 ```tsx showLineNumbers


### PR DESCRIPTION
## Description

This PR fixes the import-path mismatch reported in **#881** by aligning docs usage snippets with the actual install target path.

The issue was that some docs showed imports from `@/registry/magicui/*`, while installed components are intended to be imported from `@/components/ui/*`.

### Changes
- Updated usage imports in docs from `@/registry/magicui/*` to `@/components/ui/*`.
- Fixed the following component docs:
  - `magic-card`
  - `video-text`
  - `pixel-image`
  - `shine-border`
- Verified there are no remaining `@/registry/magicui/*` usage imports in `content/docs` and `content/blog`.

## Motivation

- Prevent copy-paste errors for users following docs.
- Keep import examples consistent with generated/installed component paths.
- Reduce confusion between internal registry source paths and consumer-facing app import paths.

## Breaking Changes

- None.
- This change only updates documentation examples and does not modify runtime component behavior.
