### PR TITLE
fix: add missing motion dependency for highlighter registry

### DIFF
--- a/apps/www/content/docs/components/highlighter.mdx
+++ b/apps/www/content/docs/components/highlighter.mdx
@@ -28,6 +28,12 @@ npx shadcn@latest add @magicui/highlighter
 
 <Steps>
 
+<Step>Install the following dependencies:</Step>
+
+```bash
+pnpm add motion rough-notation
+```
+
 <Step>Copy and paste the following code into your project.</Step>
 
 <ComponentSource name="highlighter" />

--- a/apps/www/public/r/highlighter-demo.json
+++ b/apps/www/public/r/highlighter-demo.json
@@ -5,6 +5,7 @@
   "title": "Highlighter Demo",
   "description": "Example showing the demo of a Highlighter",
   "dependencies": [
+    "motion",
     "rough-notation"
   ],
   "registryDependencies": [

--- a/apps/www/public/r/highlighter.json
+++ b/apps/www/public/r/highlighter.json
@@ -5,6 +5,7 @@
   "title": "Highlighter",
   "description": "A text highlighter that mimics the effect of a human-drawn marker stroke.",
   "dependencies": [
+    "motion",
     "rough-notation"
   ],
   "files": [

--- a/apps/www/public/r/registry.json
+++ b/apps/www/public/r/registry.json
@@ -1219,6 +1219,7 @@
       "title": "Highlighter",
       "description": "A text highlighter that mimics the effect of a human-drawn marker stroke.",
       "dependencies": [
+        "motion",
         "rough-notation"
       ],
       "files": [
@@ -3449,6 +3450,7 @@
       "title": "Highlighter Demo",
       "description": "Example showing the demo of a Highlighter",
       "dependencies": [
+        "motion",
         "rough-notation"
       ],
       "registryDependencies": [

--- a/apps/www/public/registry.json
+++ b/apps/www/public/registry.json
@@ -1219,6 +1219,7 @@
       "title": "Highlighter",
       "description": "A text highlighter that mimics the effect of a human-drawn marker stroke.",
       "dependencies": [
+        "motion",
         "rough-notation"
       ],
       "files": [
@@ -3449,6 +3450,7 @@
       "title": "Highlighter Demo",
       "description": "Example showing the demo of a Highlighter",
       "dependencies": [
+        "motion",
         "rough-notation"
       ],
       "registryDependencies": [

--- a/apps/www/registry.json
+++ b/apps/www/registry.json
@@ -1219,6 +1219,7 @@
       "title": "Highlighter",
       "description": "A text highlighter that mimics the effect of a human-drawn marker stroke.",
       "dependencies": [
+        "motion",
         "rough-notation"
       ],
       "files": [
@@ -3449,6 +3450,7 @@
       "title": "Highlighter Demo",
       "description": "Example showing the demo of a Highlighter",
       "dependencies": [
+        "motion",
         "rough-notation"
       ],
       "registryDependencies": [

--- a/apps/www/registry/registry-examples.ts
+++ b/apps/www/registry/registry-examples.ts
@@ -1879,7 +1879,7 @@ export const examples: Registry["items"] = [
         type: "registry:ui",
       },
     ],
-    dependencies: ["rough-notation"],
+    dependencies: ["motion", "rough-notation"],
   },
   {
     name: "animated-theme-toggler-demo",

--- a/apps/www/registry/registry-ui.ts
+++ b/apps/www/registry/registry-ui.ts
@@ -1182,7 +1182,7 @@ export const ui: Registry["items"] = [
         type: "registry:ui",
       },
     ],
-    dependencies: ["rough-notation"],
+    dependencies: ["motion", "rough-notation"],
   },
   {
     name: "animated-theme-toggler",


### PR DESCRIPTION
Closes #949

## Description
This PR fixes missing dependency metadata for the Highlighter component during shadcn installs, especially in monorepo setups.

The registry now includes both `motion` and `rough-notation`, and the docs explicitly list the manual install command. This prevents missing module errors after adding `@magicui/highlighter`.

## Changes
- add `motion` to the `highlighter` registry item dependencies
- add `motion` to the `highlighter-demo` example dependencies
- update the Highlighter docs to include `pnpm add motion rough-notation`
- regenerate registry artifacts in `apps/www/public/r` and `apps/www/public`

## Motivation
`@magicui/highlighter` imports `useInView` from `motion/react`, but the registry metadata only declared `rough-notation`.

Because of that mismatch, users adding the component through the shadcn CLI could end up with missing dependencies and build/type errors in monorepo environments.
