### PR TITLE
docs(mcp): add CODEX tab and installation instructions to documentation

### DIFF
--- a/apps/www/content/docs/mcp.mdx
+++ b/apps/www/content/docs/mcp.mdx
@@ -28,7 +28,7 @@ This is useful for Magic UI because you can now give your AI-assisted IDE direct
     <TabsTrigger value="cursor">Cursor</TabsTrigger>
     <TabsTrigger value="windsurf">Windsurf</TabsTrigger>
     <TabsTrigger value="claude">Claude</TabsTrigger>
-    <TabsTrigger value="codex">CODEX</TabsTrigger>
+    <TabsTrigger value="codex">Codex</TabsTrigger>
     <TabsTrigger value="cline">Cline</TabsTrigger>
     <TabsTrigger value="roo-cline">Roo-Cline</TabsTrigger>
   </TabsList>

--- a/apps/www/content/docs/mcp.mdx
+++ b/apps/www/content/docs/mcp.mdx
@@ -28,6 +28,7 @@ This is useful for Magic UI because you can now give your AI-assisted IDE direct
     <TabsTrigger value="cursor">Cursor</TabsTrigger>
     <TabsTrigger value="windsurf">Windsurf</TabsTrigger>
     <TabsTrigger value="claude">Claude</TabsTrigger>
+    <TabsTrigger value="codex">CODEX</TabsTrigger>
     <TabsTrigger value="cline">Cline</TabsTrigger>
     <TabsTrigger value="roo-cline">Roo-Cline</TabsTrigger>
   </TabsList>
@@ -49,6 +50,13 @@ This is useful for Magic UI because you can now give your AI-assisted IDE direct
 
     ```bash
     npx @magicuidesign/cli@latest install claude
+    ```
+
+  </TabsContent>
+  <TabsContent value="codex">
+
+    ```bash
+    npx @magicuidesign/cli@latest install codex
     ```
 
   </TabsContent>


### PR DESCRIPTION
## Description
This PR updates the MCP documentation to include **Codex** support in the installation/configuration flow.  
It complements the CLI implementation already submitted and keeps the docs aligned with the newly supported client.  
I have also completed the CLI implementation and am currently just waiting for validation/review  [Add Codex support for Magic MCP install](https://github.com/magicuidesign/cli/pull/3).

## Changes
- Added **Codex** setup/configuration instructions to the MCP docs page.
- Updated the supported clients section to include Codex.
- Aligned documentation with the CLI implementation already opened in a separate PR.

## Motivation
Codex support was requested in issue [#957](https://github.com/magicuidesign/magicui/issues/957), which asks for explicit CLI/docs support.  
Without this update, Codex users lack a documented setup path even though implementation work is already in progress in the CLI ([PR #3](https://github.com/magicuidesign/cli/pull/3)).

## Breaking Changes
None.

## Screenshots
N/A (documentation-only change; no UI impact).

> Device / Browser / Viewport: N/A

| Before | After |
| --- | --- |
| N/A | N/A |