### PR TITLE
fix(story): make tweet cards grid responsive on mobile screens

### DIFF
--- a/apps/www/content/docs/story.mdx
+++ b/apps/www/content/docs/story.mdx
@@ -23,7 +23,7 @@ I started building the foundations of this site as well as a few components and 
 
 People seem to love it and we're just getting started.
 
-<div className="mt-4 columns-3 gap-4 [&>*]:mb-4">
+<div className="mt-4 columns-1 md:columns-3 gap-4 [&>*]:mb-4">
   <Tweet id="1722659583464968612" />
   <Tweet id="1668442365625790465" />
   <Tweet id="1684613797984800768" />

--- a/apps/www/content/docs/story.mdx
+++ b/apps/www/content/docs/story.mdx
@@ -23,7 +23,7 @@ I started building the foundations of this site as well as a few components and 
 
 People seem to love it and we're just getting started.
 
-<div className="mt-4 columns-1 md:columns-3 gap-4 [&>*]:mb-4">
+<div className="mt-4 columns-1 gap-4 md:columns-3 [&>*]:mb-4">
   <Tweet id="1722659583464968612" />
   <Tweet id="1668442365625790465" />
   <Tweet id="1684613797984800768" />


### PR DESCRIPTION
## Description
Fix tweet cards grid on the Story page breaking on mobile screens. The grid was hardcoded to 3 columns with no responsive breakpoint, causing cards to overflow and clip on small viewports.

## Changes
Changed `columns-3` to `columns-1 md:columns-3` in `apps/www/content/docs/story.mdx` so the tweet grid stacks to a single column on mobile and returns to 3 columns on medium screens and above.

## Motivation
On mobile, the 3-column masonry grid in `/docs/story` was overflowing its container, cards were clipped and text was cut off. The fix mirrors the same responsive pattern already used in the homepage testimonials section (`components/sections/testimonials.tsx`).

## Breaking Changes
None.

## Screenshots

Device / Browser / Viewport: DevTools device emulation / Chrome / iPhone 14 Pro Max (430x932)

| Before | After |
| --- | --- |
| <img width="800" height="4651" alt="mui-story-b" src="https://github.com/user-attachments/assets/c190516d-34b2-46fe-a9c1-8301482c8e95" /> | <img width="800" height="5771" alt="mui-story-a" src="https://github.com/user-attachments/assets/c4e5e86f-5cb9-462c-910b-2ecd5a6949c5" /> |
