### PR TITLE
fix(globe): pin cobe to ^0.6.4 to prevent v2 install break

### DIFF
--- a/apps/www/content/docs/components/globe.mdx
+++ b/apps/www/content/docs/components/globe.mdx
@@ -32,7 +32,7 @@ npx shadcn@latest add @magicui/globe
 <Step>Install the following dependencies:</Step>
 
 ```bash
-npm install cobe motion
+npm install cobe@0.6.4 motion
 ```
 
 <Step>Copy and paste the following code into your project.</Step>

--- a/apps/www/public/r/globe.json
+++ b/apps/www/public/r/globe.json
@@ -5,7 +5,7 @@
   "title": "Globe",
   "description": "An autorotating, interactive, and highly performant globe made using WebGL.",
   "dependencies": [
-    "cobe",
+    "cobe@^0.6.4",
     "motion"
   ],
   "files": [

--- a/apps/www/public/r/registry.json
+++ b/apps/www/public/r/registry.json
@@ -432,7 +432,7 @@
       "title": "Globe",
       "description": "An autorotating, interactive, and highly performant globe made using WebGL.",
       "dependencies": [
-        "cobe",
+        "cobe@^0.6.4",
         "motion"
       ],
       "files": [

--- a/apps/www/public/registry.json
+++ b/apps/www/public/registry.json
@@ -432,7 +432,7 @@
       "title": "Globe",
       "description": "An autorotating, interactive, and highly performant globe made using WebGL.",
       "dependencies": [
-        "cobe",
+        "cobe@^0.6.4",
         "motion"
       ],
       "files": [

--- a/apps/www/registry.json
+++ b/apps/www/registry.json
@@ -432,7 +432,7 @@
       "title": "Globe",
       "description": "An autorotating, interactive, and highly performant globe made using WebGL.",
       "dependencies": [
-        "cobe",
+        "cobe@^0.6.4",
         "motion"
       ],
       "files": [

--- a/apps/www/registry/registry-ui.ts
+++ b/apps/www/registry/registry-ui.ts
@@ -404,7 +404,7 @@ export const ui: Registry["items"] = [
     title: "Globe",
     description:
       "An autorotating, interactive, and highly performant globe made using WebGL.",
-    dependencies: ["cobe", "motion"],
+    dependencies: ["cobe@^0.6.4", "motion"],
     files: [
       {
         path: "magicui/globe.tsx",


### PR DESCRIPTION
## Description
Pin `cobe` to `^0.6.4` in the globe registry item so `npx shadcn@latest add @magicui/globe` keeps installing a version compatible with the shipped component code.

## Changes
- `apps/www/registry/registry-ui.ts`: globe dependencies `"cobe"` → `"cobe@^0.6.4"`
- Regenerated registry JSON files via `pnpm build:registry`

## Motivation
`cobe` v2.0 (released 2026-03-18) replaced the `onRender` callback with `globe.update()`. Without a version pin, the registry resolves `cobe` to v2.x while the shipped `globe.tsx` still uses `onRender`, breaking the component for new installs (related: #963).

## Breaking Changes
None.

## Screenshots
N/A — registry metadata change only.
