### PR TITLE
fix(docs): correct mobile copy page menu positioning

### DIFF
--- a/apps/www/components/docs-copy-page.tsx
+++ b/apps/www/components/docs-copy-page.tsx
@@ -12,7 +12,6 @@ import {
 } from "@/components/ui/dropdown-menu"
 import {
   Popover,
-  PopoverAnchor,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
@@ -112,7 +111,6 @@ export function DocsCopyPage({ page, url }: { page: string; url: string }) {
   return (
     <Popover>
       <div className="bg-secondary group/buttons relative flex rounded-lg *:[[data-slot=button]]:focus-visible:relative *:[[data-slot=button]]:focus-visible:z-10">
-        <PopoverAnchor />
         <Button
           variant="secondary"
           size="sm"
@@ -143,7 +141,7 @@ export function DocsCopyPage({ page, url }: { page: string; url: string }) {
         </PopoverTrigger>
         <PopoverContent
           className="bg-background/70 dark:bg-background/60 w-52 !origin-center rounded-lg shadow-sm backdrop-blur-sm"
-          align="start"
+          align="end"
         >
           {Object.entries(menuItems).map(([key, value]) => (
             <Button


### PR DESCRIPTION


## Description
  Fix the mobile `Copy Page` menu positioning on docs pages.

  This removes the custom empty `PopoverAnchor` from `DocsCopyPage` and keeps the mobile menu
  on the standard Radix trigger/content path so the popover is positioned relative to the
  actual trigger button.

  ## Changes
  - removed the unused custom `PopoverAnchor` from `DocsCopyPage`
  - kept the mobile menu on the default `PopoverTrigger` + `PopoverContent` pattern
  - adjusted the mobile popover alignment to  `align="end"`
  - left desktop `DropdownMenu` behavior unchanged

  ## Motivation
  On mobile, the `Copy Page` action menu could render in the wrong position because the
  component defined a custom popover anchor without anchoring it to a real element.

  Removing that anchor fixes the positioning issue at the source while keeping the
  implementation aligned with how other Radix menus are structured in the codebase.

  ## Breaking Changes
  None.

  ## Screenshots
  > Device / Browser / Viewport: iPhone/Chrome or Safari/mobile viewport under `sm`

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="402" height="860" alt="image" src="https://github.com/user-attachments/assets/c7870c16-5e5a-474e-a658-d08e3a4a43fe" />
</td>
<td>
<img width="402" height="859" alt="image" src="https://github.com/user-attachments/assets/28f8eb8d-e0d1-420c-8d19-c73bb9196557" />
</td>
</tr>
</table>