### PR TITLE
fix: step circles overflow left edge

### DIFF
--- a/apps/www/styles/globals.css
+++ b/apps/www/styles/globals.css
@@ -513,11 +513,12 @@
 
   .steps > h3 {
     counter-increment: steps;
+    @apply max-lg:relative max-lg:ps-8;
   }
 
   .steps > h3:before {
     @apply border-background bg-muted absolute inline-flex h-9 w-9 items-center justify-center rounded-full border-4 text-center -indent-px font-mono text-base font-medium;
-    @apply mt-[-4px] ml-[-50px];
+    @apply mt-[-4px] ml-[-50px] max-lg:ms-0 max-lg:-start-2;
     content: counter(steps);
   }
 


### PR DESCRIPTION
## Description
Step circles on the installation page overflow beyond the left viewport edge on smaller screens. Switched from a hardcoded `margin-left: -50px` to responsive `max-lg:` variants.

## Changes
- Bug fix: Replaced `margin-left: -50px` with `max-lg:ms-0 max-lg:-start-2` on `.steps > h3:before` to keep the circle within the viewport on smaller screens
- Enhancement: Added `max-lg:relative max-lg:ps-8` to `.steps > h3` to anchor the absolutely positioned circle and prevent text overlap

## Motivation
On screens narrower than 1024px, the step number circles were partially outside the visible area, breaking the installation guide's usability on tablets and phones.

## Breaking Changes
None

## Screenshots
> Device / Browser / Viewport: Mobile / <1024px


<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="300" alt="image" src="https://github.com/user-attachments/assets/cf3bdf12-9f3e-459c-876f-b16f2ade8849" />
</td>
<td>
<img width="500"  alt="step-circles" src="https://github.com/user-attachments/assets/234d0b48-0e75-44ca-bcd0-442413398a42" />
</td>
</tr>
</table>







