### PR TITLE
ci: add production build check and lighten pre-commit hooks

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: ["*"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -150,6 +154,41 @@ jobs:
         run: pnpm install
 
       - run: pnpm registry-deps:check
+
+  build:
+    runs-on: ubuntu-latest
+    name: pnpm build
+    steps:
+      - uses: actions/checkout@v6
+
+      # pnpm must be installed before setup-node so its built-in pnpm cache works
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 9.15.0
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Restore Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: apps/www/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/www/**/*.[jt]s', 'apps/www/**/*.[jt]sx', 'apps/www/**/*.mdx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
+
+      - name: Build
+        run: pnpm build
+        env:
+          NEXT_PUBLIC_APP_URL: https://magicui.design
 
   registry-drift:
     runs-on: ubuntu-latest

--- a/apps/www/.prettierignore
+++ b/apps/www/.prettierignore
@@ -1,1 +1,4 @@
 registry/__index__.tsx
+registry.json
+public/registry.json
+public/r/

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,20 +3,30 @@ pre-commit:
   commands:
     build:registry:
       glob: "**/registry/**/*.{ts,tsx}"
-      run: pnpm build:registry && git add --all
-      stage_fixed: true
-    typecheck:
-      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-      run: pnpm typecheck
-      stage_fixed: true
+      # www-scoped script only (the root build:registry also runs a
+      # whole-project lint:fix + format:fix). Stage generated artifacts
+      # by explicit path — never `git add --all`. CI's registry-drift job
+      # checks these same paths, so a new artifact path can't slip through.
+      run: >
+        pnpm --filter=www build:registry &&
+        git add apps/www/registry.json apps/www/registry/__index__.tsx
+        apps/www/public/registry.json apps/www/public/r
+        apps/www/public/llms.txt apps/www/public/llms-full.txt
     lint:fix:
-      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-      run: pnpm lint:fix
+      root: "apps/www/"
+      glob: "*.{js,ts,cjs,mjs,jsx,tsx}"
+      run: pnpm exec eslint --fix --no-warn-ignored {staged_files}
       stage_fixed: true
-    format:fix:silent:
-      glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-      run: pnpm format:fix:silent
+    format:fix:
+      root: "apps/www/"
+      glob: "*.{js,ts,cjs,mjs,jsx,tsx,json,jsonc,mdx}"
+      run: pnpm exec prettier --log-level silent --write --cache {staged_files}
       stage_fixed: true
+
+pre-push:
+  commands:
+    typecheck:
+      run: pnpm typecheck
 
 commit-msg:
   commands:


### PR DESCRIPTION
## Summary

- **CI**: Add a `build` job to `code-check.yml` — PRs that break the Next.js production build now fail CI. No secrets needed (all env reads in the build path are defensive), so fork PRs build identically. Caches `apps/www/.next/cache`, uses `setup-node@v4` + `node-version-file: .nvmrc`. A workflow-level `concurrency` group cancels superseded runs on rapid pushes.
- **Hooks**: Rework `lefthook.yml` around fast, staged-only pre-commit (~30–120s → ~2–10s per commit):
  - lint/format run directly on staged files instead of the whole project
  - registry build uses the www-scoped script (the root script also ran a hidden full-project lint+format) and stages generated artifacts by explicit path instead of `git add --all`
  - full typecheck moves from pre-commit to pre-push
- **Guard**: Generated registry JSON added to `.prettierignore` so the format hook can never reformat `build:registry` output away from its `JSON.stringify` form (which would trip the registry-drift CI check).

## Why the build job matters

While validating this change on a fork that predated #979, the new job immediately caught the tweet-card prerender regression (`TypeError: c is not iterable`) that used to slip through CI — exactly the class of failure this check gates. Verified green against current `main` (full 381-page prerender, ~5 min cold / ~2–4 min with warm cache).

## Contributor-facing changes

- Type errors no longer block `git commit` — they block `git push` and CI.
- Everything removed locally remains covered by CI (lint / format / tsc / registry-drift jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEkEs1cWYWSvshxhxJZ6od