### PR TITLE
ci: make PR check failures self-explanatory and document CI gates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,3 +18,8 @@
 | Before | After |
 | --- | --- |
 |  |  |
+
+## Checklist
+- [ ] `pnpm check` passes locally
+- [ ] `pnpm build:registry` was run and the generated files are committed (CI verifies this on every PR)
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(marquee): add reverse prop`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,5 +21,6 @@
 
 ## Checklist
 - [ ] `pnpm check` passes locally
-- [ ] `pnpm build:registry` was run and the generated files are committed (CI verifies this on every PR)
+- [ ] `pnpm build` passes locally
+- [ ] `pnpm build:registry` was run and the generated files are committed (if you changed `registry/` or `config/site.ts` — CI verifies this on every PR)
 - [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(marquee): add reverse prop`)

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -43,7 +43,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - run: pnpm lint
+      - name: pnpm lint
+        run: |
+          pnpm lint || {
+            echo "::error::Lint errors found. Run 'pnpm lint:fix' locally, fix any remaining errors, then commit."
+            exit 1
+          }
 
   format:
     runs-on: ubuntu-latest
@@ -81,7 +86,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - run: pnpm format:check
+      - name: pnpm format:check
+        run: |
+          pnpm format:check || {
+            echo "::error::Formatting issues found. Run 'pnpm format:fix' locally, then commit."
+            exit 1
+          }
 
   tsc:
     runs-on: ubuntu-latest
@@ -153,7 +163,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - run: pnpm registry-deps:check
+      - name: pnpm registry-deps:check
+        run: |
+          pnpm registry-deps:check || {
+            echo "::error::Registry example dependencies are out of sync. Run 'pnpm registry-deps:fix && pnpm build:registry', then commit the generated files."
+            exit 1
+          }
 
   build:
     runs-on: ubuntu-latest
@@ -224,6 +239,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # build:registry must stay regeneration-only: repo-wide lint/format fixes
+      # here could fail on unrelated errors and mask the real drift result.
       - name: Build registry artifacts
         run: pnpm build:registry
 
@@ -238,10 +255,8 @@ jobs:
             apps/www/public/llms-full.txt)"
 
           if [ -n "$CHANGED_FILES" ]; then
-            echo "Registry artifacts are out of date."
+            echo "::error::Registry artifacts are out of date. Run 'pnpm build:registry' and commit the generated files."
             echo "Changed files:"
             printf '%s\n' "$CHANGED_FILES"
-            echo "Run: pnpm build:registry"
-            echo "Then commit generated files."
             exit 1
           fi

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -166,7 +166,7 @@ jobs:
       - name: pnpm registry-deps:check
         run: |
           pnpm registry-deps:check || {
-            echo "::error::Registry example dependencies are out of sync. Run 'pnpm registry-deps:fix && pnpm build:registry', then commit the generated files."
+            echo "::error::Registry example dependencies are out of sync. Run 'pnpm registry-deps:fix && pnpm build:registry', then commit registry-examples.ts along with the generated files."
             exit 1
           }
 
@@ -255,7 +255,7 @@ jobs:
             apps/www/public/llms-full.txt)"
 
           if [ -n "$CHANGED_FILES" ]; then
-            echo "::error::Registry artifacts are out of date. Run 'pnpm build:registry' and commit the generated files."
+            echo "::error::Registry artifacts are out of date. Run 'pnpm build:registry', then commit the generated files."
             echo "Changed files:"
             printf '%s\n' "$CHANGED_FILES"
             exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to MagicUI! We appreciate your support and look forward to your contributions. This guide will help you understand the directory structure and provide detailed instructions on how to add a new component to MagicUI.
 
-Read the [example PR](https://github.com/magicuidesign/magicui/pull/780) to learn which files you need to add. **You only need to change 5 files to add a new component or effect** and it only takes around 10 minutes of work!
+Read the [example PR](https://github.com/magicuidesign/magicui/pull/780) to learn which files you need to add. **You only need to write 5 files to add a new component or effect** (plus committing the registry artifacts that `pnpm build:registry` generates for you) and it only takes around 10 minutes of work!
 
 Once done, open a pull request from your forked repo to the main repo [here](https://github.com/magicuidesign/magicui/compare).
 
@@ -32,6 +32,8 @@ Once done, open a pull request from your forked repo to the main repo [here](htt
    ```
 
 5. **Install dependencies**
+
+   Requires Node 22 (see `.nvmrc`) and pnpm 9.
 
    ```bash
    pnpm i
@@ -239,6 +241,8 @@ Make sure to add any necessary dependencies, tailwind configurations, or other p
 pnpm build:registry
 ```
 
+This regenerates the registry artifacts (`registry.json`, `registry/__index__.tsx`, `public/registry.json`, `public/r`, `public/llms.txt`, `public/llms-full.txt`). **Commit the generated files together with your component** — CI verifies they are up to date and fails otherwise.
+
 ## Adding to the showcase
 
 ### 1. Create your showcase as a MDX file
@@ -259,6 +263,43 @@ affiliation: YC S25, raised $10M
 ### 2. Create an image
 
 Upload an image of your site to `public/showcase/website-name.png`
+
+## Before Opening a Pull Request
+
+Running the checks below locally first saves you a round trip with CI:
+
+1. **Run all checks**
+
+   ```bash
+   pnpm check
+   ```
+
+   This runs `lint`, `typecheck`, `format:check`, and `registry-deps:check` — the four fastest CI gates. Most issues can be auto-fixed:
+
+   ```bash
+   pnpm lint:fix
+   pnpm format:fix
+   pnpm registry-deps:fix
+   ```
+
+   Note: `registry-deps:fix` updates `registry/registry-examples.ts`, so run `pnpm build:registry` afterwards to regenerate the artifacts.
+
+2. **Build the registry and commit the generated files** (see "6. Build registry" above) if you changed anything under `registry/` or `config/site.ts`.
+
+3. **Make sure the production build passes**
+
+   ```bash
+   pnpm build
+   ```
+
+   CI runs this too, and it is the slowest gate — catching a build break locally saves the longest round trip.
+
+4. **Use Conventional Commits** (enforced by local git hooks, not by CI)
+
+   Commit messages are validated by [commitlint](https://commitlint.js.org/) (e.g., `feat(marquee): add reverse prop`, `fix(globe): prevent crash on resize`). Use the same format for your PR title.
+
+> [!NOTE]
+> Git hooks (installed automatically with `pnpm i` via lefthook) run lint/format fixes on staged files and regenerate registry artifacts on commit, plus `typecheck` on push. They do not cover `registry-deps:check` or the production build.
 
 ## Ask for Help
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,7 +274,7 @@ Running the checks below locally first saves you a round trip with CI:
    pnpm check
    ```
 
-   This runs `lint`, `typecheck`, `format:check`, and `registry-deps:check` — the four fastest CI gates. Most issues can be auto-fixed:
+   This runs `lint`, `typecheck`, `format:check`, and `registry-deps:check` — four of the six CI gates. Most issues can be auto-fixed:
 
    ```bash
    pnpm lint:fix
@@ -299,7 +299,7 @@ Running the checks below locally first saves you a round trip with CI:
    Commit messages are validated by [commitlint](https://commitlint.js.org/) (e.g., `feat(marquee): add reverse prop`, `fix(globe): prevent crash on resize`). Use the same format for your PR title.
 
 > [!NOTE]
-> Git hooks (installed automatically with `pnpm i` via lefthook) run lint/format fixes on staged files and regenerate registry artifacts on commit, plus `typecheck` on push. They do not cover `registry-deps:check` or the production build.
+> Git hooks (installed automatically with `pnpm i` via lefthook) run lint/format fixes on staged files and regenerate registry artifacts when you commit files under `registry/`, plus `typecheck` on push. They do not cover `registry-deps:check`, the production build, or a `config/site.ts`-only change — run `pnpm build:registry` yourself in that case.
 
 ## Ask for Help
 

--- a/apps/www/scripts/sync-example-registry-dependencies.mts
+++ b/apps/www/scripts/sync-example-registry-dependencies.mts
@@ -656,7 +656,7 @@ async function main() {
       console.error("registry example dependency mismatches found:")
       console.error(blockingIssueSummary)
       console.error("Run: pnpm registry-deps:fix && pnpm build:registry")
-      console.error("Then commit the generated files.")
+      console.error("Then commit registry-examples.ts and the generated files.")
       process.exit(1)
     }
 

--- a/apps/www/scripts/sync-example-registry-dependencies.mts
+++ b/apps/www/scripts/sync-example-registry-dependencies.mts
@@ -655,6 +655,8 @@ async function main() {
     if (blockingIssues.length > 0) {
       console.error("registry example dependency mismatches found:")
       console.error(blockingIssueSummary)
+      console.error("Run: pnpm registry-deps:fix && pnpm build:registry")
+      console.error("Then commit the generated files.")
       process.exit(1)
     }
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,10 +3,9 @@ pre-commit:
   commands:
     build:registry:
       glob: "**/registry/**/*.{ts,tsx}"
-      # www-scoped script only (the root build:registry also runs a
-      # whole-project lint:fix + format:fix). Stage generated artifacts
-      # by explicit path — never `git add --all`. CI's registry-drift job
-      # checks these same paths, so a new artifact path can't slip through.
+      # Same regeneration-only command as the root build:registry script and
+      # CI's registry-drift job. Stage generated artifacts by explicit path —
+      # never `git add --all`. CI's registry-drift job checks these same paths.
       run: >
         pnpm --filter=www build:registry &&
         git add apps/www/registry.json apps/www/registry/__index__.tsx

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "lint:fix": "turbo run lint:fix",
     "typecheck": "turbo run typecheck",
     "format:fix": "turbo run format:fix",
-    "format:fix:silent": "turbo run format:fix -- --log-level silent",
     "format:check": "turbo run format:check",
     "registry-deps:check": "pnpm --filter=www registry-deps:check",
-    "build:registry": "pnpm --filter=www build:registry && pnpm --filter=www lint:fix && pnpm format:fix:silent",
+    "registry-deps:fix": "pnpm --filter=www registry-deps:fix",
+    "build:registry": "pnpm --filter=www build:registry",
     "check": "pnpm lint && pnpm typecheck && pnpm format:check && pnpm registry-deps:check"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
Makes CI failures self-explanatory for contributors and documents the CI gates in CONTRIBUTING. The **only CI/artifact behavior change** is one line: the registry-drift job (and the root `build:registry` script it calls) now runs the regeneration-only, www-scoped command — the same one the lefthook pre-commit hook already uses (follow-up to #988). Generated artifacts are byte-identical: regenerating with the simplified command leaves `git status` clean across all six checked paths.

One side effect for local workflows: the root `build:registry` no longer runs an incidental repo-wide `eslint --fix`. That auto-fixing is still covered by lefthook's pre-commit hook (staged files), and CONTRIBUTING now documents `pnpm lint:fix` explicitly.

## Changes
- **`code-check.yml`**: the lint / format / registry-deps / registry-drift gates now print the exact fix command (`pnpm lint:fix`, `pnpm format:fix`, `pnpm registry-deps:fix && pnpm build:registry`, `pnpm build:registry`) as `::error::` annotations on failure — same pattern the drift job already used
- **`package.json`**: `build:registry` no longer chains repo-wide `lint:fix` + `format:fix` (no-op for artifacts; unrelated lint errors could previously fail artifact generation and mask the real drift result); removed the now-unused `format:fix:silent`; exposed `registry-deps:fix` at the root
- **`sync-example-registry-dependencies.mts`**: check failure now tells you to run `registry-deps:fix && build:registry` and to commit `registry-examples.ts` (which the fix rewrites) along with the regenerated artifacts
- **`CONTRIBUTING.md`**: new "Before Opening a Pull Request" section (`pnpm check`, production build, committing generated artifacts, Conventional Commits), Node 22 / pnpm 9 prerequisites, and a note that generated artifacts must be committed
- **`PULL_REQUEST_TEMPLATE.md`**: 4-item pre-flight checklist
- **`lefthook.yml`**: comment updated to reflect the simplified root script (command unchanged)

## Motivation
Two CI gates were effectively dead ends for external contributors: `registry-deps:check` failed without mentioning that a fix command exists, and commitlint rejected first commits while Conventional Commits wasn't documented anywhere. Separately, an unrelated lint error could turn the drift job red with no lint output in its log, sending contributors down the wrong path. Every avoided round trip is a full push → wait → search → fix cycle saved, for every contributor.

## Breaking Changes
None. Job and step names are unchanged (required status checks unaffected). `pnpm build:registry` produces byte-identical artifacts.

## Screenshots
N/A (no UI changes)

## Checklist
- [x] `pnpm check` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm build:registry` was run and the generated files are committed (CI verifies this on every PR)
- [x] PR title follows Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wJuxcamc1gSFVu9AcKkGp