### PR TITLE
fix(readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Have questions, comments or feedback? [Join our discord](http://magicui.design/d
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=magicuidesign/magicui&type=Date)](https://www.star-history.com/#magicuidesign/magicui&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=magicuidesign/magicui&type=Date)](https://star-history.dera.page/#magicuidesign/magicui&Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README has stopped rendering because of GitHub stargazer API restrictions, so the stats section no longer displays. This updates the chart to use a working data source so the star history displays correctly again.