### PR TITLE
fix(registry): correct smooth-cursor dependency (framer-motion -> motion)

### DIFF
--- a/apps/www/public/r/registry.json
+++ b/apps/www/public/r/registry.json
@@ -194,7 +194,7 @@
       "type": "registry:ui",
       "description": "A customizable, physics-based smooth cursor animation component with spring animations and rotation effects",
       "dependencies": [
-        "framer-motion"
+        "motion"
       ],
       "files": [
         {

--- a/apps/www/public/r/smooth-cursor.json
+++ b/apps/www/public/r/smooth-cursor.json
@@ -4,7 +4,7 @@
   "type": "registry:ui",
   "description": "A customizable, physics-based smooth cursor animation component with spring animations and rotation effects",
   "dependencies": [
-    "framer-motion"
+    "motion"
   ],
   "files": [
     {

--- a/apps/www/public/registry.json
+++ b/apps/www/public/registry.json
@@ -194,7 +194,7 @@
       "type": "registry:ui",
       "description": "A customizable, physics-based smooth cursor animation component with spring animations and rotation effects",
       "dependencies": [
-        "framer-motion"
+        "motion"
       ],
       "files": [
         {

--- a/apps/www/registry.json
+++ b/apps/www/registry.json
@@ -194,7 +194,7 @@
       "type": "registry:ui",
       "description": "A customizable, physics-based smooth cursor animation component with spring animations and rotation effects",
       "dependencies": [
-        "framer-motion"
+        "motion"
       ],
       "files": [
         {

--- a/apps/www/registry/registry-ui.ts
+++ b/apps/www/registry/registry-ui.ts
@@ -173,7 +173,7 @@ export const ui: Registry["items"] = [
         type: "registry:ui",
       },
     ],
-    dependencies: ["framer-motion"],
+    dependencies: ["motion"],
   },
   {
     name: "progressive-blur",


### PR DESCRIPTION
## Summary
- `smooth-cursor` declares `framer-motion` but imports from `motion/react`, so `npx shadcn add smooth-cursor` installs the wrong package → switch to `motion` (matches the other 29 motion-based items)
- Regenerate registry artifacts (`registry.json`, `public/r/smooth-cursor.json`)

## Test plan
- [x] `pnpm --filter=www build:registry` — only expected diffs
- [x] eslint / prettier on changed files
- [x] `pnpm typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vLm4CqtxKWGZZMsax2pZh
