### PR TITLE
docs: Fix Manual variable css in rainbow-button.mdx

### DIFF
--- a/apps/www/content/docs/components/rainbow-button.mdx
+++ b/apps/www/content/docs/components/rainbow-button.mdx
@@ -40,11 +40,11 @@ Add the following to your `globals.css` file:
 
 ```css title="app/globals.css" showLineNumbers {2-6}
 :root {
-  --color-1: 0 100% 63%;
-  --color-2: 270 100% 63%;
-  --color-3: 210 100% 63%;
-  --color-4: 195 100% 63%;
-  --color-5: 90 100% 63%;
+  --color-1: hsl(0 100% 63%);
+  --color-2: hsl(270 100% 63%);
+  --color-3: hsl(210 100% 63%);
+  --color-4: hsl(195 100% 63%);
+  --color-5: hsl(90 100% 63%);
 }
 ```
 


### PR DESCRIPTION
old vars are incorrect and do not work :/

## Description
the old vars are just numbers (bare numbers aren't a color), the browser just drops the whole background declaration since its invalid syntax

## Motivation
old vars did not work and thats annoying to have on prod

## Breaking Changes
makes manual implementation easier for the users

## Checklist
- [ ] `pnpm check` passes locally
- [ ] `pnpm build` passes locally
- [ ] `pnpm build:registry` was run and the generated files are committed (if you changed `registry/` or `config/site.ts` — CI verifies this on every PR)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat(marquee): add reverse prop`)
